### PR TITLE
Fix deployment pipeline: layered JAR launcher, artifact-based deploys, Render trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,14 @@ jobs:
     - name: Build with Maven
       run: mvn verify -B
 
+    - name: Upload JAR artifact
+      if: github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-jar
+        path: target/*.jar
+        retention-days: 1
+
 #    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
 #    - name: Update dependency graph
 #      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,13 +9,35 @@ on:
 
 jobs:
   build-and-push:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Download JAR artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: app-jar
+          path: target
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Prepare build context
+        id: prepare
+        run: |
+          if ls target/*.jar 1>/dev/null 2>&1; then
+            mkdir -p deploy-context
+            cp target/*.jar deploy-context/app.jar
+            cp Dockerfile.deploy deploy-context/Dockerfile
+            echo "dockerfile=deploy-context/Dockerfile" >> "$GITHUB_OUTPUT"
+            echo "context=./deploy-context" >> "$GITHUB_OUTPUT"
+          else
+            echo "dockerfile=Dockerfile" >> "$GITHUB_OUTPUT"
+            echo "context=." >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker BuildX
         uses: docker/setup-buildx-action@v3
@@ -40,9 +62,18 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ${{ steps.prepare.outputs.context }}
+          file: ${{ steps.prepare.outputs.dockerfile }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Trigger Render deploy
+        run: |
+          curl -s -X POST "https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
+            -d '{"clearCache": "do_not_clear"}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ COPY --from=layers /application/extracted/snapshot-dependencies/ ./
 COPY --from=layers /application/extracted/application/ ./
 
 EXPOSE 10000
-ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar app.jar --server.port=${PORT:-10000}"]
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} org.springframework.boot.loader.launch.JarLauncher --server.port=${PORT:-10000}"]

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -22,4 +22,4 @@ COPY --from=layers /application/extracted/snapshot-dependencies/ ./
 COPY --from=layers /application/extracted/application/ ./
 
 EXPOSE 10000
-ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar app.jar --server.port=${PORT:-10000}"]
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} org.springframework.boot.loader.launch.JarLauncher --server.port=${PORT:-10000}"]

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,0 +1,25 @@
+# Stage: extract Spring Boot application layers
+FROM eclipse-temurin:25-jre-alpine AS layers
+WORKDIR /application
+COPY app.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
+
+# Stage: final runtime image
+FROM eclipse-temurin:25-jre-alpine
+
+VOLUME /tmp
+
+# Configure non-root user
+RUN adduser -S spring-user
+USER spring-user
+
+WORKDIR /application
+
+# Copy Spring Boot application layers
+COPY --from=layers /application/extracted/dependencies/ ./
+COPY --from=layers /application/extracted/spring-boot-loader/ ./
+COPY --from=layers /application/extracted/snapshot-dependencies/ ./
+COPY --from=layers /application/extracted/application/ ./
+
+EXPOSE 10000
+ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar app.jar --server.port=${PORT:-10000}"]


### PR DESCRIPTION
## Summary

- Fix runtime crash in both Dockerfiles: replaced `-jar app.jar` with `org.springframework.boot.loader.launch.JarLauncher` — the layered/extracted approach never copies `app.jar` into the runtime stage, so `-jar` fails with "Unable to access jarfile"
- Add artifact-based deploy pipeline: `build.yml` uploads JAR on main, `deploy.yml` downloads it and uses lightweight `Dockerfile.deploy` (no builder stage), falling back to full `Dockerfile` if no artifact available
- Fix manual `workflow_dispatch` trigger path (was gated on `workflow_run.conclusion` only)
- Add Render API deploy trigger after image push (requires `RENDER_SERVICE_ID` and `RENDER_API_KEY` secrets)

## Verification

- `git diff main...HEAD` reviewed — 4 files changed, 67 insertions, 3 deletions
- Launcher class `org.springframework.boot.loader.launch.JarLauncher` verified from actual fat JAR contents (Spring Boot 4.0.6)