### PR TITLE
Skip Codecov upload on Dependabot PRs due to missing secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       run: mvn verify -B
 
     - name: Upload coverage to Codecov
-      if: always()
+      if: always() && github.actor != 'dependabot[bot]'
       uses: codecov/codecov-action@v6
       with:
         files: target/site/jacoco/jacoco.xml


### PR DESCRIPTION
## Problem
Dependabot PRs fail the build pipeline at the "Upload coverage to Codecov" step because GitHub doesn't pass repository secrets to PRs created by `dependabot[bot]`.

## Fix
Added a condition to the Codecov step to skip it when the actor is `dependabot[bot]`:

```yaml
if: always() && github.actor != 'dependabot[bot]'
```