### PR TITLE
Configure Claude Code permissions for common read-only commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find *)",
+      "Bash(grep *)",
+      "Bash(egrep *)",
+      "Bash(fgrep *)",
+      "Bash(rg *)",
+      "Bash(fd *)",
+      "Bash(fdfind *)",
+      "Bash(tree *)",
+      "Bash(file *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(wc *)",
+      "Bash(sort *)",
+      "Bash(uniq *)",
+      "Bash(basename *)",
+      "Bash(dirname *)",
+      "Bash(realpath *)",
+      "Bash(readlink *)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}


### PR DESCRIPTION
## Summary
Add `.claude/settings.json` with an allowlist for common read-only bash commands to reduce permission prompts during development.

## Changes
- Added permissions for: `find`, `grep`/`egrep`/`fgrep`, `rg`, `fd`/`fdfind`, `tree`, `file`, `head`, `tail`, `wc`, `sort`, `uniq`, `basename`, `dirname`, `realpath`, `readlink`

## Context
Commands like `cd`, `ls`, `cat` are already auto-allowed by Claude Code's built-in safety validation, but other common read-only commands like `find` and `grep` were prompting for approval. This change streamlines the development workflow by pre-approving these safe operations.