### PR TITLE
Replace jjwt-jackson with jjwt-gson for Spring Boot 4/Jackson 3 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,14 +190,8 @@
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt-jackson</artifactId>
+      <artifactId>jjwt-gson</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.passay</groupId>


### PR DESCRIPTION
## Summary

- Replace `jjwt-jackson` with `jjwt-gson` in `pom.xml`
- Gson adapter works with the same JJWT API — no Java code changes needed
- All 87 tests pass

## Verification

- `./mvnw verify -B` — BUILD SUCCESS, 87/87 tests passed