### PR TITLE
Align Continue framework with TESTING.md test pyramid

### DIFF
--- a/.claude/agents/red-agent.md
+++ b/.claude/agents/red-agent.md
@@ -19,16 +19,20 @@ You write exactly ONE test following TDD red phase with failure prediction.
 2. Read layer template (see table below)
 3. **Existence check** — before writing anything, search for existing production code that already provides the capability under test (API client in another feature, port method from a prior scenario, logic function, adapter implementation). For acceptance/rest layers: also search for existing `@WebApi`/`AbstractApi` classes that already wrap the target controller — add new endpoint methods to the existing class rather than creating a new one. If found → **STOP**. Report that the step should be skipped `[S]` (and its green counterpart) with the reason. Do not write the test.
 4. **Trivial-logic check (frontend-logic and frontend-api only)** — ask: does this scenario require branching, computation, validation, or data transformation in the target layer? If the "implementation" would be a constant, an unconditional pass-through, or a value that never varies by input — there is no logic to test. **Identity/pass-through mappings are trivial** — if the function would forward fields unchanged (same structure, same values, no renaming/filtering/defaults), that is not transformation. Diagnostic: "If I removed this function and the caller used the input directly, would anything break?" If no → **STOP.** Report `[S]` for this step and its green counterpart, noting the behavior is purely presentational (handled in the component during `align-design`).
-5. Analyze existing tests in the layer
-6. **PREDICT the expected failure** (error message, exception type, or assertion failure)
-7. **Domain field gate (usecase/adapter layers only)** — before writing domain classes, list every domain class and field you plan to create. For each field, cite the exact Statements line that reads or asserts it. See `.claude/templates/workflow/red-phase-formats.md` for the domain field gate table format. A field used only inside a factory method but never read or asserted by any test or Statements line is **unreferenced -- REMOVE it**. Only KEEP fields survive to code. If removing a field makes another class unnecessary, delete that class too.
-8. Write ONE test WITHOUT the test disable marker
-9. **Post-implementation trivial-test gate (frontend-logic and frontend-api only)** — review every assertion in the test just written. If every assertion compares an output field to the same input field passed in (output ≈ input), the test is trivial — it only proves the function returns what it received. **STOP.** Delete the test and stubs, report `[S]` for this step and its green counterpart. This catches cases where step 4 misjudged.
-10. **RUN the test** to verify it fails
-11. **COMPARE -- field by field.** Write the comparison table from `.claude/templates/workflow/red-phase-formats.md`. Compare Type, Message, and Status fields. "Both are AssertionError" does NOT mean the messages match. Compare the message text literally.
-12. **If ANY cell says NO: loop back.** Update your prediction to match what actually happened (or fix the test setup if the wrong code path ran), then go to step 10 and re-run. Keep looping until ALL cells say YES. You may NOT add the test disable marker until all cells say YES — there are no exceptions, no "the red state is still valid" justification, no architectural reasoning that bypasses this. The loop exists because a wrong prediction means you don't fully understand the code path, and that misunderstanding will lead to mistakes in GREEN.
-13. **All cells say YES → add the test disable marker.**
-14. Report: files created, domain field gate table, comparison table from final iteration (all YES), next step
+5. **Pyramid gate (adapter layers only)** — before writing an adapter test, verify the test is needed at this level per `TESTING.md`:
+   - **rest**: does the endpoint have validation logic (request body/DTO validation) or error-response mapping (business exception → HTTP status)? If the endpoint is a simple delegation with no validation → `[S]`. Happy path is covered by acceptance tests.
+   - **db**: is the query a custom `@Query`, native SQL, or Specification? Simple Spring Data derived query → `[S]`.
+   - If `[S]`, report the skip reason and stop. Do not write the test.
+6. Analyze existing tests in the layer
+7. **PREDICT the expected failure** (error message, exception type, or assertion failure)
+8. **Domain field gate (usecase/adapter layers only)** — before writing domain classes, list every domain class and field you plan to create. For each field, cite the exact Statements line that reads or asserts it. See `.claude/templates/workflow/red-phase-formats.md` for the domain field gate table format. A field used only inside a factory method but never read or asserted by any test or Statements line is **unreferenced -- REMOVE it**. Only KEEP fields survive to code. If removing a field makes another class unnecessary, delete that class too.
+9. Write ONE test WITHOUT the test disable marker
+10. **Post-implementation trivial-test gate (frontend-logic and frontend-api only)** — review every assertion in the test just written. If every assertion compares an output field to the same input field passed in (output ≈ input), the test is trivial — it only proves the function returns what it received. **STOP.** Delete the test and stubs, report `[S]` for this step and its green counterpart. This catches cases where step 4 misjudged.
+11. **RUN the test** to verify it fails
+12. **COMPARE -- field by field.** Write the comparison table from `.claude/templates/workflow/red-phase-formats.md`. Compare Type, Message, and Status fields. "Both are AssertionError" does NOT mean the messages match. Compare the message text literally.
+13. **If ANY cell says NO: loop back.** Update your prediction to match what actually happened (or fix the test setup if the wrong code path ran), then go to step 11 and re-run. Keep looping until ALL cells say YES. You may NOT add the test disable marker until all cells say YES — there are no exceptions, no "the red state is still valid" justification, no architectural reasoning that bypasses this. The loop exists because a wrong prediction means you don't fully understand the code path, and that misunderstanding will lead to mistakes in GREEN.
+14. **All cells say YES → add the test disable marker.**
+15. Report: files created, domain field gate table, comparison table from final iteration (all YES), next step
 
 ## Failure Prediction Format
 
@@ -81,7 +85,21 @@ ONE test means **one test class per domain class** (value object, entity, policy
 
 ## Adapter Layer: Multiple Test Methods
 
-For adapter layers (db, rest, email, security), ONE test means **one test class per port method**. The class may contain multiple test methods covering different cases (happy path, error, edge) of the same port method.
+For adapter layers, follow the test pyramid from `TESTING.md`. Each level tests only what is NOT covered by the level above.
+
+**rest adapter** (Level 2 — web slice):
+- ONE test class per controller endpoint that has validation or error-handling logic.
+- **Test**: validation errors (422), business-exception-to-status-code mapping (401, 404, 422).
+- **Do NOT test**: happy path — covered by acceptance tests (Level 1).
+- **Skip `[S]`**: when the endpoint is a simple delegation (controller → usecase → response) with no request validation and no error mapping.
+- Happy-path response shape is verified by the acceptance test.
+
+**db adapter** (infrastructure):
+- Only for custom `@Query`, native SQL, Specifications, JOIN FETCH — see `.claude/tech/java-spring/templates/db/test-class.md`.
+- Simple Spring Data derived queries (`findByXxx`, `existsByXxx`) → `[S]`.
+
+**email / security / other adapters**:
+- Only corner cases not covered by acceptance tests.
 
 - Use **class-level** test disable marker (not per-method) — one marker disables all methods
 - Predict failure for **each** test method separately

--- a/.claude/rules/tdd-rules.md
+++ b/.claude/rules/tdd-rules.md
@@ -4,6 +4,24 @@
 
 Never write production code without a failing test first.
 
+## Test Pyramid Alignment
+
+Each test level covers only what is NOT tested by the level above it. Per `TESTING.md`:
+
+| Level | Scope | What to test | What NOT to test |
+|-------|-------|-------------|-----------------|
+| 1 — e2e acceptance | `@ApplicationIntegrationTest`, full context, HTTP | Happy path (1-2 tests per use case) | Error cases, validation, corner cases |
+| 2 — web slice | `@WebTest`, auto-mocked dependencies | Validation errors, business exception → HTTP status mapping | Happy path (covered by Level 1) |
+| 3 — usecase unit | Pure unit, InMemory fakes, no Spring | Corner cases of business logic | Happy path (covered by Level 1) |
+| 4 — domain unit | No mocks, pure Java | Value object validation, entity state transitions, policies | Happy path (covered by Level 1) |
+| Infra (ad-hoc) | `@RepositoryTest` / `@DataJpaTest` | Complex queries only (`@Query`, native SQL, Specifications) | Simple `findByXxx` queries |
+
+**Rules:**
+- When writing a test at level N, verify the same behavior is not already covered by level N-1.
+- **Adapter tests are optional**: skip (`[S]`) when the adapter is a simple delegation with no validation/error logic.
+- **One acceptance scenario per endpoint behavior category** — NOT one per business variant. If 5 domain states produce the same HTTP response (same status, different message), that's ONE acceptance scenario. Per-state message variations belong in domain unit tests (Level 4).
+- Acceptance tests are the "long" tests. Keep them few. Move detail to cheaper lower levels.
+
 ### RED Phase
 - Create: test class, test methods, Statements/Scope helpers, minimal production stubs (using the not-implemented marker from the Conventions table in `technology.md`). **Never delegate to a working method** — delegating returns a valid result, which is partial implementation, not a stub.
 - **Domain stubs: only what the test touches.** Domain entities and value objects created in RED must contain only the fields the current test actually references or asserts. Don't preemptively add fields, relationships, or entire classes from the ADR/design that future scenarios will need. Add fields when a test demands them, not before.

--- a/.claude/tech/java-spring/templates/rest/test-class.md
+++ b/.claude/tech/java-spring/templates/rest/test-class.md
@@ -25,6 +25,11 @@ Project uses `@WebTest` meta-annotation that auto-mocks ALL controller dependenc
 - `@Test` method: call API → `AssertionResponse.assert*()`
 - ONE `@Test` method per test class in RED; add `@Disabled`
 
+**What to test at this level** (Level 2 — Web Slice, per `TESTING.md`):
+- Validation errors: `assertBindingError("__files/.../out.json")`
+- Business exception → HTTP status code mapping: mock service to throw exception, assert status + error body
+- Do NOT test happy path — covered by acceptance tests (Level 1, `@ApplicationIntegrationTest`)
+
 ## Test API Class Rules
 
 - Extend `AbstractApi`, annotate with `@WebApi`
@@ -58,9 +63,10 @@ For success responses: `assertOk("__files/.../out.json")` or inline JSON string.
 - `AbstractApi`: `src/test/java/by/iivanov/rpm/testing/api/AbstractApi.java`
 - `AssertionResponse`: `src/test/java/by/iivanov/rpm/testing/api/AssertionResponse.java`
 - `@WebApi`: `src/test/java/by/iivanov/rpm/testing/api/WebApi.java`
-- Example test class: `src/test/java/by/iivanov/rpm/iam/auth/infrastructure/web/AuthResourceTest.java`
 - Example API class: `src/test/java/by/iivanov/rpm/iam/auth/fixtures/AuthApi.java`
 - JSON template: `src/test/resources/__files/iam/auth/web/login_beanValidation_out.json`
+
+**Note:** `AuthResourceTest.java` contains a happy-path test at Level 2 — this pattern is being corrected. Do NOT use it as a template for new web slice tests. New tests at this level should cover validation errors and error response mapping only.
 
 ## Key Paths
 

--- a/.claude/templates/spec/test-spec-format.md
+++ b/.claude/templates/spec/test-spec-format.md
@@ -1,6 +1,6 @@
 # Test Spec — Category Formats & Ordering
 
-## 01_API_Tests.md (8-12 tests)
+## 01_API_Tests.md (5-8 tests)
 
 Tests are ordered for **sequential TDD implementation** — each section builds on the previous one. You can implement group N without needing group N+1.
 
@@ -9,6 +9,19 @@ Start every generated file with this header:
 > **Implementation Order**: Tests are numbered for sequential TDD implementation.
 > Start with [story-specific progression summary].
 ```
+
+**Test Pyramid Alignment (CRITICAL):**
+
+Follow `TESTING.md`. Acceptance tests (Level 1, e2e) cover **happy path only**. Do NOT generate a separate acceptance scenario for every business variant that shares the same HTTP code path.
+
+| Rule | Example |
+|------|---------|
+| One happy path per endpoint | POST /login → 200 with session |
+| One representative error per endpoint (if the endpoint can fail) | POST /login → 401 (wrong password) |
+| Multiple business variants of the SAME error → merge into ONE scenario, test variants at lower levels (domain/usecase) | PENDING/LOCKED/INACTIVE all return 401 with different messages → ONE acceptance test "Login with non-ACTIVE user returns 401", individual messages tested at domain level |
+| Validation errors with different field combinations → ONE scenario per endpoint, test individual constraint violations at DTO/web level | Password too short + missing uppercase + missing digit → ONE "Password policy violation" scenario |
+
+**Acceptance ≠ exhaustive.** If 5 different domain states produce the same HTTP response (same status, same error structure, different message), that is ONE acceptance scenario — not 5. The per-state message variations belong in domain unit tests (Level 4).
 
 **Ordering principles (apply in this priority):**
 1. **Prerequisite guards first** — generate guard scenarios for every prerequisite listed in the story spec. See Prerequisite Guard Checklist below. Do NOT include generic auth (401 for unauthenticated) tests — those are tested globally by the security filter, not per-story.

--- a/.claude/templates/tdd/red-rest.md
+++ b/.claude/templates/tdd/red-rest.md
@@ -1,5 +1,28 @@
 # Controller Test Template -- Universal
 
+## Test Pyramid — What to Test at This Level
+
+Per project `TESTING.md`, this is **Level 2 (Web Slice)**. Each level tests only what is NOT covered by the level above.
+
+| Level | What | Where |
+|-------|------|-------|
+| Level 1 (e2e) | Happy path | `@ApplicationIntegrationTest` |
+| **Level 2 (this level)** | **Validation errors + error response mapping** | `@WebTest` |
+| Level 3 (usecase) | Corner cases of business logic | Unit tests with InMemory fakes |
+| Level 4 (domain) | Value object validation, state transitions | Unit tests, no mocks |
+
+**Test at this level:**
+- Request DTO validation (422 with field errors)
+- Business exception → HTTP status code mapping (401, 404, 422)
+- Error response body format (Problem Detail / RFC 9457)
+
+**Do NOT test at this level:**
+- Happy path — already covered by acceptance tests (Level 1)
+- Business logic correctness — covered by usecase tests (Level 3)
+- Response DTO field content for successful responses — covered by acceptance tests
+
+**Skip `[S]` when** the endpoint is a simple delegation: controller extracts params → calls usecase → returns response. No validation, no error mapping. The acceptance test alone is sufficient.
+
 ## Test Pattern
 
 1. **Create test API method** (if new endpoint): add method to existing `@WebApi` class, or create new API class extending `AbstractApi`.

--- a/.claude/templates/workflow/adapter-discovery-checklist.md
+++ b/.claude/templates/workflow/adapter-discovery-checklist.md
@@ -49,6 +49,11 @@ List domain exceptions thrown by the usecase or its domain objects.
    - Response exists but is missing fields the test asserts → needs adapter steps
    - Response matches test expectations → `[S]`
 
+**Pyramid filter — before adding steps, apply this gate:**
+- **Simple delegation endpoint** (extracts params → calls usecase → returns response, no request validation) → `[S]` with reason "simple delegation — acceptance test covers happy path". Example: `GET /activate?token=...` that just calls `activationService.validateToken(token)` and returns the result.
+- **Validation endpoint** (has `@Valid` request body, DTO constraints) → add `red-adapter rest` / `green-adapter rest`.
+- **Error-mapping endpoint** (controller must catch business exceptions and map to HTTP status codes) → add adapter steps. Example: controller catches `TokenExpiredException` → 422 response.
+
 ### Example: missed happy-path
 
 **Scenario:** "Create task with title only" — acceptance test expects `{ id, title, position, createdAt }`.


### PR DESCRIPTION
Level 2 (web slice) tests must not cover happy path — that belongs to Level 1 acceptance tests. Added pyramid gates to red-agent, adapter-discovery, test-spec generator, and templates.