### PR TITLE
docs: Story 1 improvements backlog + Improvements-vs-Bugs convention

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -139,3 +139,17 @@ Tasks follow the same TDD discipline as stories: `/test-review` after red phases
 **Scoped steps:** Progress should only include TDD steps for layers the fix actually touches — applies to tasks, and to individual story scenarios. If the fix is pure CSS, don't generate logic/API/align-design steps. If the fix is backend-only, don't generate frontend steps. Affected layers are determined from the spec at creation time.
 
 Operational details: `/task` skill (creation, sections, progress format), `/continue` skill (execution, dispatch, adapter discovery).
+
+## Improvements vs Bugs
+
+Not everything found during QA is a bug. Classify before acting:
+
+- **Bug** — behaviour is broken or regressed: it was specified **and** built, and now fails. → a separate `bug` task with a backing GitHub issue (see "Bug Tasks → GitHub Issues").
+- **Improvement** — an enhancement, or behaviour that was under-specified or missing **by design** (never built, never a scenario). → do **not** open a bug task. Collect it in a per-story **improvements backlog**: `ProductSpecification/stories/NN-story-slug/improvements.md` — one running list per story.
+
+Diagnostic: *"Did it ever work / was it specified-and-built?"* Yes → bug task + issue. No (never built / under-spec) → improvements backlog.
+
+Improvements backlog conventions:
+- Items accumulate as `Open` (ids `I1`, `I2`, …), each capturing observed behaviour, spec context, current code state, and scope options. Move an item to `Done` with the resolving task/PR.
+- **Architecture is deferred:** finish the base story in its current form first, then revisit the backlog and design solutions (an ADR, or promote the list into a dedicated improvement story).
+- A real bug discovered while filling the backlog still goes to a separate bug task + issue — never folded into the improvements list.

--- a/ProductSpecification/stories/01-user-login/improvements.md
+++ b/ProductSpecification/stories/01-user-login/improvements.md
@@ -1,0 +1,42 @@
+# Story 1 (User Login) — Improvements Backlog
+
+Running list of **enhancements** to the login / Story-1 flow found during QA.
+
+## How this list works
+
+- Items here are **improvements** — under-specified or missing-by-design behaviour, not regressions.
+- **Real bugs** (broken or regressed behaviour) do **not** go here — file them as separate `bug`
+  tasks with a backing GitHub issue (same pattern as Tasks 12/13/14 → #129/#130/#131).
+- **Architecture is deferred:** finish Story 1 in its current form first, then revisit this list and
+  design solutions (ADRs, or promote this file into its own improvement story).
+- Add items as `Open`; move to `Done` (with the resolving task/PR) once addressed.
+
+## Open
+
+### I1 — No post-login navigation / logged-in state (found 2026-06-08)
+
+**Observed:** after a successful `POST /api/auth/login` (200 OK) the SPA stays on `/login`.
+`LoginPage.submitLogin()` does nothing on success — only the `catch` branch runs (error banner);
+there is no `router.push` and no `/me` call.
+
+**Spec context:** `01_UserLogin.md` Flow §4 ("Frontend calls GET /api/auth/me to display current
+user info") and Screen States ("Logged-in state: user info displayed via /me endpoint") imply a
+logged-in state, but it was never turned into a UI scenario (`tests/02_UI_Tests.md` §6 Navigation has
+only **6.1** activation→login) nor implemented. No concrete destination page is named.
+
+**Current state of the code:**
+- `/` route → `HomePage.vue` — a placeholder ("RPM / Remote Patient Monitoring"); nothing routes to
+  it after login, and it does not call `/me`.
+- No auth-based router guard (`/` is public; `SecurityConfig` permits `GET /`).
+- Backend `/api/auth/me` exists (Story 1 backend Scenario 5.1) but the frontend never calls it.
+
+**Scope options to decide at design time:**
+- *Minimal:* `router.push('/')` on successful login.
+- *Spec-aligned:* fetch `GET /api/auth/me` → render a real logged-in state (beginning of an
+  authenticated app shell).
+- *Likely also needed:* auth router guard, redirect-after-login back to the originally requested URL,
+  and a defined landing for unauthenticated users.
+
+## Done
+
+_(none yet)_


### PR DESCRIPTION
## Summary

Introduces a lightweight way to track **login / Story-1 enhancements** found during QA, separate from bug tasks, plus the first item.

- **`.claude/rules/workflow.md`** — new "Improvements vs Bugs" section. Classifies QA findings: *broken/regressed* (was specified-and-built, now fails) → a `bug` task with a GitHub issue; *enhancement / under-specified / missing-by-design* (never built, never a scenario) → a per-story **improvements backlog** (`improvements.md`), with architecture deferred until the base story is finished. Includes the diagnostic and backlog conventions.
- **`ProductSpecification/stories/01-user-login/improvements.md`** — the backlog itself, seeded with **I1 — no post-login navigation / logged-in state**: after a 200 `POST /api/auth/login` the SPA stays on `/login` (`LoginPage.submitLogin()` does nothing on success — no `router.push`, no `/me`). The spec's "logged-in state via /me" was never turned into a UI scenario nor implemented; `/`→`HomePage.vue` is a placeholder with no post-login routing or guard.

## Why

QA of the deployed login surfaced behaviour that isn't a regression but an under-spec gap. Folding such findings into bug tasks would muddy the bug tracker; collecting them per-story keeps them visible until we do the architecture pass after Story 1.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)