### PR TITLE
Mark Task 7 Step 6 done in progress.md

### DIFF
--- a/ProductSpecification/tasks/done/7-refactoring-full-stack-contract-e2e/progress.md
+++ b/ProductSpecification/tasks/done/7-refactoring-full-stack-contract-e2e/progress.md
@@ -75,4 +75,4 @@ script), starts the backend jar with `SPRING_PROFILES_ACTIVE=fullstack` (+ stand
 overrides), runs `scripts/seed-fullstack.sh` after health, starts Vite frontend, runs
 `npm run test:e2e:fullstack`. Does NOT run on every PR and does NOT touch the existing
 `frontend-e2e` job.
-- [~] refactor (nightly-fullstack-e2e.yml)
+- [x] refactor (nightly-fullstack-e2e.yml)


### PR DESCRIPTION
Follow-up to #149. The Task 7 completion commit captured Step 6 as `[~]` (a rename+edit staging glitch), and PR #149 was merged before the correcting commit landed — so `done/7-refactoring-full-stack-contract-e2e/progress.md` on `main` shows Step 6 in-progress even though the task is complete (folder already in `tasks/done/`).

One-line fix: `[~]` → `[x]` for `refactor (nightly-fullstack-e2e.yml)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)