### PR TITLE
Task 168: Fix flaky activation.api "Body has already been read" (GC body-read race)

### DIFF
--- a/ProductSpecification/tasks/168-bug-flaky-activation-api-body-read/progress.md
+++ b/ProductSpecification/tasks/168-bug-flaky-activation-api-body-read/progress.md
@@ -1,0 +1,17 @@
+# Task 168: Flaky activation.api test — Body already read -- Progress
+
+Type: bug
+
+## Spec
+- [x] spec
+
+## Frontend
+
+### Fix: gate the router import in apiFetch behind status 401 to close the body-read race
+Timing/flaky fix — the defect is a non-deterministic MSW + undici body-stream race widened by a
+cold `await import('@/router')` on the success path, not deterministic runtime logic. No
+meaningful unit RED can pin a timing race; the existing tests
+(`fetch.api.test.ts`, `activation.api.test.ts`) characterize all paths and must stay green.
+- [S] red-frontend-api (no deterministic unit RED for a timing race; existing tests guard behaviour)
+- [ ] green-frontend-api (fetch.api.ts: import/redirect only when status === 401; all existing tests green)
+- [ ] verify (full `vitest run` green; stress loop to confirm no flake)

--- a/ProductSpecification/tasks/168-bug-flaky-activation-api-body-read/progress.md
+++ b/ProductSpecification/tasks/168-bug-flaky-activation-api-body-read/progress.md
@@ -7,11 +7,13 @@ Type: bug
 
 ## Frontend
 
-### Fix: gate the router import in apiFetch behind status 401 to close the body-read race
-Timing/flaky fix — the defect is a non-deterministic MSW + undici body-stream race widened by a
-cold `await import('@/router')` on the success path, not deterministic runtime logic. No
-meaningful unit RED can pin a timing race; the existing tests
-(`fetch.api.test.ts`, `activation.api.test.ts`) characterize all paths and must stay green.
-- [S] red-frontend-api (no deterministic unit RED for a timing race; existing tests guard behaviour)
-- [ ] green-frontend-api (fetch.api.ts: import/redirect only when status === 401; all existing tests green)
-- [ ] verify (full `vitest run` green; stress loop to confirm no flake)
+### Fix: buffer the response body in apiFetch before any await (close the GC body-read race)
+Root cause confirmed by deterministic Docker reproduction: GC finalizes the unread undici/MSW
+body in the gap between `fetch()` and `response.json()` that Task 8's `apiFetch` opened. A unit
+RED cannot pin a GC race in normal runs; the existing tests (`fetch.api.test.ts`,
+`activation.api.test.ts`, `login.api.test.ts`) characterize all paths and must stay green, and
+the race is reproduced under forced GC (`--expose-gc`) in a CI-matched Linux container.
+- [x] reproduce (Docker node:22.13.0 + forced GC: pre-fix 25/25 fail; delay-only 0/95 — GC is the cause)
+- [S] red-frontend-api (no deterministic unit RED for a GC race; existing tests guard behaviour)
+- [x] green-frontend-api (fetch.api.ts: buffer body via arrayBuffer before the router import; null-body guard)
+- [x] verify (local full `vitest run` 23/23; lint/type-check clean; Docker forced-GC full suite 0/25)

--- a/ProductSpecification/tasks/168-bug-flaky-activation-api-body-read/spec.md
+++ b/ProductSpecification/tasks/168-bug-flaky-activation-api-body-read/spec.md
@@ -16,44 +16,59 @@ TypeError: Body is unusable: Body has already been read
 On the success (200) path the body is read exactly once, yet undici reports it as already
 consumed. The failure fails the `frontend-build` job → fails the **Java CI with Maven**
 workflow on `main` → the dependent **Docker Build and Push** job is skipped, so the
-**application did not deploy** (merge commit `886bd9e`, both run attempts failed). Locally on
-Windows it passes (5/5 full `vitest run`); it reproduces on the Linux CI runner.
+**application did not deploy** (merge commit `886bd9e`, both run attempts failed).
 
-## Root cause
+## Root cause (confirmed)
+
+**Garbage collection finalizes the unread undici/MSW response body during the gap between
+`fetch()` resolving and `response.json()` being read.**
 
 Introduced by Task 8 (PR #167) via the new `apiFetch` wrapper
-(`frontend/src/app/logic/fetch.api.ts`). Previously `validateActivationToken` did `fetch(...)`
-then immediately `await response.json()`. Now an extra async hop sits between them:
+(`frontend/src/app/logic/fetch.api.ts`). Before Task 8, `validateActivationToken` did
+`fetch(...)` then **immediately** `await response.json()` — no gap, never flaked. `apiFetch`
+inserted an `await redirectToLoginWhenUnauthorized(status)` → `await import('@/router')` between
+the response arriving and the body being read. Under the full suite's memory pressure on the
+Linux CI runner, a GC cycle fires inside that gap and releases the still-unread body stream;
+the subsequent `response.json()` then throws "Body has already been read".
 
-```
-const response = await fetch(...)
-await redirectToLoginWhenUnauthorized(response.status)  // -> await import('@/router')  (cold first load)
-return response                                          // caller then: await response.json()
-```
-
-`activation.api.test.ts` does not import `@/router` statically, so this is the **first cold
-load** of the router module (parses the router plus every route component). That heavyweight
-`await import('@/router')` widens the window between the response arriving and its body being
-read, exposing an MSW v2 + undici body-stream race that manifests on the Linux CI runner.
-(`fetch.api.test.ts` imports `@/router` statically, so the dynamic import is cache-warm there
-and the race does not show.)
+The mechanism was confirmed by deterministic reproduction in a Linux container (Node 22.13.0,
+the CI version): with `--expose-gc` and forced GC churn in the gap, the pre-Task-8/pre-fix code
+fails **25/25**; a mere time delay of up to 2000 ms with no GC never fails (0/95). It is the GC,
+not the delay, that disturbs the body. The same gap exists on every `apiFetch` body-reading
+path (e.g. login via `csrf.ts` → `throwLoginError`), so the defect is a whole class, not one
+test — the activation 200 path is simply the one with the heaviest gap (a cold `@/router`
+import that first-compiles four route SFCs), so it crossed the threshold on real CI first.
 
 ## Solution
 
-In `apiFetch`, perform the router import / redirect **only when `status === 401`** — the
-redirect is only ever needed for 401 (`shouldRedirectToLogin` already requires it). For
-200 / 422 / 403 the function returns the response with no extra async hop, restoring the
-back-to-back `fetch` → `json()` timing and closing the race window for the body-reading paths.
-All existing behaviour stays unchanged; the redirect-on-401 path is preserved.
+Buffer the response body into memory **immediately after `fetch()`, before any `await`**, and
+return a reconstructed in-memory `Response`. Once the body is read into an `ArrayBuffer`, no
+live undici stream remains for GC to finalize, so callers may `await` freely (router import,
+CSRF handshake, …) and still read `.json()`/`.text()` safely. A null-body guard handles
+101/103/204/205/304. This closes the entire class (activation, login, and any future
+`apiFetch` caller), not just the one observed test.
+
+Trade-off: every response body is read into memory (negligible for the small JSON auth
+responses; `apiFetch` is not used for streaming), and the reconstructed `Response` drops
+`url`/`redirected`/`type` (unused — the test reads `request.url` from the MSW handler, and the
+401 redirect uses the router path).
 
 ## Key Files
 
-- `frontend/src/app/logic/fetch.api.ts` — gate the redirect/router import behind `status === 401`
+- `frontend/src/app/logic/fetch.api.ts` — buffer the body before the router import; reconstruct Response
 - `frontend/src/app/__tests__/fetch.api.test.ts` — existing guard (401 redirect, 403 stay, 401 via activation)
 - `frontend/src/features/auth/__tests__/activation.api.test.ts` — the flaky test (200 success, 422 expired)
+- `frontend/src/features/auth/__tests__/login.api.test.ts` — same class, latent (login via csrf.ts)
 
 ## Reproduction
 
-- CI (Linux): run the full `vitest run` (frontend-build job) — intermittently/reliably fails on
-  the 200 success-path test with "Body has already been read".
-- Local (Windows): not reproducible (5/5 green full runs).
+Deterministic, in a Linux container matching CI (`node:22.13.0`, `--cpuset-cpus=0-3`,
+`CI=true`, `NODE_OPTIONS=--expose-gc`), driving GC churn (allocate + `global.gc()`) in the gap
+between `fetch` and `response.json()`:
+
+- Pre-fix `apiFetch` (unconditional `await import('@/router')`): activation **25/25 fail**; full
+  suite under continuous GC pressure also fails on `login.api` **15/15**.
+- Buffering fix: full suite under the same GC pressure **0/25 fail**; normal run 23/23.
+
+Not reproducible on the Windows host or in the container without forced GC (0/120) — real CI
+hit it because the full suite's natural memory pressure triggers GC inside the heaviest gap.

--- a/ProductSpecification/tasks/168-bug-flaky-activation-api-body-read/spec.md
+++ b/ProductSpecification/tasks/168-bug-flaky-activation-api-body-read/spec.md
@@ -1,0 +1,59 @@
+# Task 168: Flaky activation.api test — Body already read
+
+Type: bug
+Issue: #168
+
+## Problem
+
+The frontend unit test `src/features/auth/__tests__/activation.api.test.ts > Activation API
+Client > returns the login and email for a valid activation token` intermittently fails on CI:
+
+```
+TypeError: Body is unusable: Body has already been read
+ ❯ validateActivationToken src/features/auth/logic/activation.api.ts:17:26   // return (await response.json())
+```
+
+On the success (200) path the body is read exactly once, yet undici reports it as already
+consumed. The failure fails the `frontend-build` job → fails the **Java CI with Maven**
+workflow on `main` → the dependent **Docker Build and Push** job is skipped, so the
+**application did not deploy** (merge commit `886bd9e`, both run attempts failed). Locally on
+Windows it passes (5/5 full `vitest run`); it reproduces on the Linux CI runner.
+
+## Root cause
+
+Introduced by Task 8 (PR #167) via the new `apiFetch` wrapper
+(`frontend/src/app/logic/fetch.api.ts`). Previously `validateActivationToken` did `fetch(...)`
+then immediately `await response.json()`. Now an extra async hop sits between them:
+
+```
+const response = await fetch(...)
+await redirectToLoginWhenUnauthorized(response.status)  // -> await import('@/router')  (cold first load)
+return response                                          // caller then: await response.json()
+```
+
+`activation.api.test.ts` does not import `@/router` statically, so this is the **first cold
+load** of the router module (parses the router plus every route component). That heavyweight
+`await import('@/router')` widens the window between the response arriving and its body being
+read, exposing an MSW v2 + undici body-stream race that manifests on the Linux CI runner.
+(`fetch.api.test.ts` imports `@/router` statically, so the dynamic import is cache-warm there
+and the race does not show.)
+
+## Solution
+
+In `apiFetch`, perform the router import / redirect **only when `status === 401`** — the
+redirect is only ever needed for 401 (`shouldRedirectToLogin` already requires it). For
+200 / 422 / 403 the function returns the response with no extra async hop, restoring the
+back-to-back `fetch` → `json()` timing and closing the race window for the body-reading paths.
+All existing behaviour stays unchanged; the redirect-on-401 path is preserved.
+
+## Key Files
+
+- `frontend/src/app/logic/fetch.api.ts` — gate the redirect/router import behind `status === 401`
+- `frontend/src/app/__tests__/fetch.api.test.ts` — existing guard (401 redirect, 403 stay, 401 via activation)
+- `frontend/src/features/auth/__tests__/activation.api.test.ts` — the flaky test (200 success, 422 expired)
+
+## Reproduction
+
+- CI (Linux): run the full `vitest run` (frontend-build job) — intermittently/reliably fails on
+  the 200 success-path test with "Body has already been read".
+- Local (Windows): not reproducible (5/5 green full runs).

--- a/frontend/src/app/logic/fetch.api.ts
+++ b/frontend/src/app/logic/fetch.api.ts
@@ -1,11 +1,23 @@
 import { LOGIN_PATH, shouldRedirectToLogin } from '@/app/logic/unauthorized-redirect.logic';
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? '';
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
 
 export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   const response = await fetch(`${BASE_URL}${path}`, init);
-  await redirectToLoginWhenUnauthorized(response.status);
-  return response;
+  const buffered = await bufferResponse(response);
+  await redirectToLoginWhenUnauthorized(buffered.status);
+  return buffered;
+}
+
+async function bufferResponse(response: Response): Promise<Response> {
+  const buffer = await response.arrayBuffer();
+  const body = NULL_BODY_STATUSES.has(response.status) ? null : buffer;
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }
 
 async function redirectToLoginWhenUnauthorized(status: number): Promise<void> {


### PR DESCRIPTION
Fixes #168.

## Problem

The frontend unit test `activation.api.test.ts > returns the login and email for a valid
activation token` intermittently failed on CI:

```
TypeError: Body is unusable: Body has already been read
 ❯ validateActivationToken src/features/auth/logic/activation.api.ts:17:26
```

The failure failed the `frontend-build` job → failed **Java CI with Maven** on `main` → the
dependent **Docker Build and Push** job was skipped, so the **app did not deploy** (merge
commit `886bd9e`, both run attempts failed).

## Root cause (confirmed)

**Garbage collection finalizes the unread undici/MSW response body in the gap between
`fetch()` resolving and `response.json()` being read.** Task 8 (#167) added the `apiFetch`
wrapper, which inserted `await import('@/router')` between the response arriving and the
caller's body read. Before Task 8 the call was `fetch(...)` then immediately `await
response.json()` — no gap, never flaked. Under the full suite's memory pressure on the Linux CI
runner, a GC cycle fires inside that gap and releases the still-unread body stream.

The heaviest gap (a cold `@/router` import that first-compiles four route SFCs) crossed the
threshold first → the `activation` 200 path. The same gap is latent on every `apiFetch`
body-reading path (e.g. login via `csrf.ts` → `throwLoginError`).

## Fix

Buffer the response body into memory **immediately after `fetch()`, before any `await`**, and
return a reconstructed in-memory `Response` (with a null-body guard for 101/103/204/205/304).
Once the body is an `ArrayBuffer`, no live undici stream remains for GC to finalize, so callers
may `await` freely and read `.json()` safely. This closes the whole class, not just one test.

Trade-off: every response body is read into memory (negligible for small JSON auth responses;
`apiFetch` is not used for streaming); the reconstructed `Response` drops
`url`/`redirected`/`type` (unused).

## Verification

Deterministic reproduction in a CI-matched Linux container (`node:22.13.0`, `CI=true`,
`--expose-gc`) with forced GC churn in the gap:

| | normal run | full suite under aggressive GC |
|---|---|---|
| pre-fix (`await import` in the gap) | — | activation 25/25 fail; login.api 15/15 fail |
| delay only, no GC | — | 0/95 (a delay is not the cause — GC is) |
| **buffering fix** | 23/23 | **0/25** |

Not reproducible without forced GC (0/120) — real CI hit it via the suite's natural memory
pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)