### PR TITLE
docs: link Story 1 I5 backlog item to issue #199

### DIFF
--- a/ProductSpecification/stories/01-user-login/improvements.md
+++ b/ProductSpecification/stories/01-user-login/improvements.md
@@ -82,6 +82,8 @@ fold into a "Login hardening / resilience" story. Marked `[S] deferred` in `prog
 
 ### I5 — Dead "Request a new activation email" link needs a resend-activation feature (found 2026-06-20)
 
+**Issue:** #199 (opened 2026-06-21, split out of #189 on closure).
+
 **Observed:** the inactive-account error banner (`LoginErrorBanner.vue`, rendered in Scenario 3.2)
 contains a "Request a new activation email" link with `href="#"` — it goes nowhere.
 


### PR DESCRIPTION
Records the new tracking issue **#199** in Story 1's improvements backlog item **I5** (the dead "Request a new activation email" link → resend-activation feature), split out of #189 when it was closed.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)