### PR TITLE
docs(prompt): extract oversized agents/skills into templates (A1/A2)

### DIFF
--- a/.claude/agents/red-agent.md
+++ b/.claude/agents/red-agent.md
@@ -65,65 +65,14 @@ Frontend layers:
 - **Playwright: NEVER navigate via URL** — see `frontend-rules.md` "FORBIDDEN in-app navigation via URL" rule. Find or create a Statements `navigate*` method that clicks through the UI.
 - **NEVER inject storage Fakes into Statements** — Statements must set up data through usecases, not by pre-seeding Fake storage directly. This applies to ALL storage ports including read-only, count-only, and aggregation ports. If setup through usecases is complex, extract compound Statements methods. See `tdd-rules.md` Assertion Rules.
 
-## Acceptance Layer: Running Backend Required
+## Per-Layer Test Notes
 
-Acceptance tests need a live backend. Predictions must be about feature behavior (see `tdd-rules.md`).
-
-0. Before running the test, ensure the shared test DB is up — see `.claude/tech/java-spring/infrastructure.md` → "Test Database" (idempotent; reused across runs, never stopped). This also applies when running a `db` adapter test (`@Tag("db")`).
-1. Before running the test, ensure the backend is up (`/run-backend` or check health endpoint)
-2. Predict the **actual application-level failure** — assertion error, wrong HTTP status, missing data, etc.
-3. If the feature is already fully implemented and the test would pass, the prediction is "test passes" — skip straight to `green-acceptance` (mark red-usecase/green-usecase/adapters as `[S]` with reason)
-4. If the test fails (new implementation needed), verify that `progress.md` has a `design` step after `red-acceptance`. If missing, add it — `design` is mandatory for every scenario requiring new implementation.
-5. **One action, assert all consequences** (see `tdd-rules.md`). If the scenario adds a new observable consequence (e.g. an email, an event, persisted state) to an action ALREADY covered by an existing acceptance test, **extend that test** with new `then` assertions instead of creating a parallel acceptance class for the same action — Level 1 runs with the full context (DB, SMTP, …) already up, so a second full-context test for the same action is wasted wall-clock.
-
-## Domain Layer: Optional, One Test Class per Domain Class
-
-Domain tests are OPTIONAL — only create when the domain object has testable logic (validation, state transitions, computed fields, business rules). Skip when: the class is a plain data holder with no behavior.
-
-ONE test means **one test class per domain class** (value object, entity, policy, enum). The class may contain multiple test methods (valid cases, invalid cases via parameterized tests).
-
-- Mark **each** test method with the test disable marker (placed per-method, not on the class — see the tech binding's `red-phase-formats.md`)
-- Predict failure for each test method
-- Parameterized tests count as one test method for prediction purposes
-
-## Adapter Layer: Multiple Test Methods
-
-For adapter layers, follow the test pyramid from `TESTING.md`. Each level tests only what is NOT covered by the level above.
-
-**rest adapter** (Level 2 — web slice):
-- ONE test class per controller endpoint that has validation or error-handling logic.
-- **Test**: validation errors (422), business-exception-to-status-code mapping (401, 404, 422).
-- **Do NOT test**: happy path — covered by acceptance tests (Level 1).
-- **Skip `[S]`**: when the endpoint is a simple delegation (controller → usecase → response) with no request validation and no error mapping.
-- Happy-path response shape is verified by the acceptance test.
-
-**db adapter** (infrastructure):
-- Only for custom `@Query`, native SQL, Specifications, JOIN FETCH — see `.claude/tech/java-spring/templates/db/test-class.md`.
-- Simple Spring Data derived queries (`findByXxx`, `existsByXxx`) → `[S]`.
-
-**email / security / other adapters**:
-- Only corner cases not covered by acceptance tests.
-
-- Mark **each** test method with the test disable marker (placed per-method, not on the class — see the tech binding's `red-phase-formats.md`)
-- Predict failure for **each** test method separately
-- Every method must fail as predicted before its marker is added
+Per-layer RED detail — acceptance (running backend required), domain (optional, one class per domain class), adapter (rest/db/email pyramid), and reuse checks before writing test infrastructure — lives in `.claude/tech/{backend}/templates/testing/red-phase-layer-notes.md`. Read it before writing a test in that layer.
 
 ## Disable Marker / Output Formats
 
 See `.claude/tech/{backend}/templates/testing/red-phase-formats.md` for test disable marker format. See `.claude/templates/workflow/red-phase-formats.md` for output summary format and the frontend/browser-testing RED-phase marker (its exact name per concern lives in the Conventions table in `ProductSpecification/technology.md`).
 
-## Reuse Checks (before writing)
-
-Before creating new test infrastructure, search for existing pieces to reuse:
-
-1. **Existing Statements assertions** — grep all Statements files (including the target file itself) for `assert*` methods covering the same domain concept or response fields (e.g., `status`, `priority`, `createdAt`). Check within the same Statements class first, then across classes. If an existing method already asserts the same fields, delegate to it and add only the scenario-specific assertions on top.
-2. **Existing Fakes** — grep `fake/` for Fakes with the same structure. If structurally identical, extract a shared base class immediately rather than copy-pasting.
-3. **Existing `@WebApi` classes (acceptance + rest layers)** — before creating a new `@WebApi`-annotated `AbstractApi` subclass, grep `fixtures/` packages for existing API classes targeting the same controller (search for the controller's `BASE_URI` or path prefix). If found → add the new endpoint method to the existing class. If not found → create a new `@WebApi` class. This applies to both acceptance tests (integration tests) and REST adapter tests (web slice tests).
-
 ## Context Files
 
-Before writing tests, read:
-1. Read `ProductSpecification/stories.md` to resolve story numbers to names and folder paths.
-2. `ProductSpecification/stories/{story}/` - story details
-3. Layer template (see "Template by Layer" table above)
-4. Existing tests in the target module
+Read the context files (stories index, story folder, layer template, existing tests) before writing — see `.claude/templates/workflow/red-phase-layer-notes.md`.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -40,28 +40,7 @@ Use the Skill tool:
 
 ## Output Format
 
-```
-## Test Results
-
-**Module:** {module}
-**Test class:** {testClass or "all"}
-
-**Result:** PASSED | FAILED | SKIPPED
-
-**Output:**
-```
-{test output}
-```
-
-**Summary:**
-- Tests run: N
-- Passed: N
-- Failed: N
-- Skipped: N
-
-**Failed tests:** (if any)
-- TestClass > testMethod() - failure reason
-```
+Report results using the structure in `.claude/templates/workflow/test-runner-output-format.md`.
 
 ## Rules
 

--- a/.claude/skills/checkstyle-review/SKILL.md
+++ b/.claude/skills/checkstyle-review/SKILL.md
@@ -16,73 +16,16 @@ That PR only updates the **reference** copy. The build actually uses `code-quali
 
 ## Procedure
 
-### 1. Get the upstream diff
+1. **Get the upstream diff** — fetch the PR diff and split it into logical changes.
+2. **Map each change to my_checks.xml** — classify as Present / Absent / New module with line ranges.
+3. **Classify each change** — Bugfix / Coverage / Style opinion / Cosmetic / Version-incompatible.
+4. **Formatter-conflict gate (MANDATORY for layout checks)** — verify layout rules don't fight Spotless + Palantir, gating against the target-branch checkstyle version.
+5. **Present the review** — one table of changes with classification, gate result, and recommendation.
+6. **Collect the user's decision** — wait for explicit per-change accept/reject before applying.
+7. **Apply** — port accepted changes into my_checks.xml; annotate rejected ones as documented deviations.
+8. **Verify** — run `./mvnw checkstyle:check -B` and report pass/fail with counts.
 
-Fetch the PR diff (GitHub MCP `pull_request_read` method `get_diff`). It contains only `google_checks.xml`. Split it into **logical changes** — group hunks that belong to one module/concern together (e.g. adding an `id` plus a new sibling `<module>` is one logical change, not two).
-
-### 2. Map each change to my_checks.xml
-
-Read `code-quality-config/checkstyle/my_checks.xml`. For each logical change determine:
-
-- **Present** — the same module/check exists in `my_checks.xml` (the change is portable and relevant).
-- **Absent** — the affected module isn't in our config (we already diverged or never adopted it; the change usually doesn't apply — note it but default to no-op).
-- **New module** — upstream adds a brand-new check we don't have.
-
-Quote the relevant `my_checks.xml` line range for each Present/New change.
-
-### 3. Classify each change
-
-- **Bugfix** — corrects a wrong regex/anchor/token (e.g. anchoring a `checkFormat` to a fully-qualified suffix). Low risk.
-- **Coverage** — extends an existing check to more tokens/cases (e.g. adding `LITERAL_DEFAULT` to a curly-brace rule). Behavioral — may newly flag existing code.
-- **Style opinion** — a new stylistic rule (e.g. forbidding decorative banner comments). Judge against this repo's own conventions (`AGENTS.md`, `.claude/rules/`).
-- **Cosmetic** — `id` attributes added purely so rules can be targeted by suppressions. Always safe.
-- **Version-incompatible** — the upstream rule uses a token or property our pinned checkstyle version doesn't accept yet (upstream tracks checkstyle *master*; our `checkstyle.version` lags). Surfaces as a config-load error (`Token "X" was not found in Acceptable tokens list`, `Property 'Y' does not exist`), not a style violation. Verdict: **reject / defer until checkstyle upgrade** — or, if the rule is wanted, bundle it with a `checkstyle.version` bump and re-gate. The formatter gate (step 4) catches these, since `checkstyle:check` fails to even load the config.
-
-### 4. Formatter-conflict gate (MANDATORY for layout checks)
-
-Java formatting in this repo is enforced by **Spotless + Palantir Java Format** (`./mvnw spotless:apply`). A checkstyle rule that governs **layout** can fight the formatter: the formatter produces one layout, checkstyle then rejects it → unfixable build.
-
-A change is **layout-related** if its module is any of: `*Wrap` (Operator/Separator), `*Curly` (Left/Right), `Indentation`, `WhitespaceAround`/`WhitespaceAfter`/`NoWhitespace*`/`GenericWhitespace`, `ParenPad`/`MethodParamPad`, `EmptyLineSeparator`, `AnnotationLocation`, `CommentsIndentation`, `NoLineWrap`. Naming, Javadoc, import-order, and Todo/comment-content checks are **not** layout-related — skip the gate for them.
-
-**Gate against the checkstyle version the BUILD uses — not whatever the PR branch pins.** The monthly PR branch is often cut from a *stale* base and carries an older `checkstyle.version` in its `pom.xml`. Running the gate with that stale version gives wrong verdicts: a rule using a token only added in a newer checkstyle will *falsely* look incompatible, and vice-versa. Before gating, read `checkstyle.version` from the **target branch** (`main`) `pom.xml` — that is the version `./mvnw verify` actually runs. If the worktree/PR-branch pins a different version, override every gate run with `-Dcheckstyle.version=<target-version>` (or rebase the PR branch onto `main` first). Always record which version the verdict was produced against.
-
-For each layout-related candidate, **verify before recommending accept**:
-
-1. On a scratch branch / stash-safe working tree, apply that single change to `my_checks.xml`.
-2. Run `./mvnw spotless:apply -q` (re-formats sources to Palantir's canonical layout — no-op if already clean).
-3. Run `./mvnw checkstyle:check -B -Dcheckstyle.version=<target-version>`.
-4. Interpret the result:
-   - **Config fails to load** (`Token "X" was not found in Acceptable tokens list`, unknown property) → **Version-incompatible** (see step 3). Not a formatter verdict — reject/defer or bundle a version bump. A failed load aborts *all* candidates in that run, so re-isolate: drop the incompatible change and re-gate the rest.
-   - **Checkstyle reports violations on formatter-owned layout** → **conflict**: the rule contradicts Palantir. Recommend **reject** (or defer) and record the conflicting message.
-   - **Clean (exit 0) and `git diff --stat` shows spotless reformatted nothing** → no conflict, safe to accept on merit. (If spotless *did* reformat sources, the new layout the formatter produced still passes checkstyle — also fine — but note it: a future PR will carry that reformat.)
-5. Revert the scratch change before moving on (each candidate is tested in isolation; final application happens in step 7). To save maven runs you may gate all layout candidates together first; only isolate when the combined run fails, to attribute the failure.
-
-Note known historical conflicts already documented in `my_checks.xml` (e.g. `TextBlockGoogleStyleFormatting`, Indentation block disabled) — if a change touches an already-disabled-for-Palantir area, flag it and default to reject.
-
-### 5. Present the review
-
-Show one table: change # | summary | present in my_checks (line range) | classification | gate result (n/a, ✅ clean, ❌ conflict, ⛔ version-incompatible) | recommendation (Accept / Reject / Optional — your call). State the checkstyle version the gate ran against. Below the table, one line per change explaining the reasoning. End by asking the user which changes to accept — they decide; recommendations are advice.
-
-### 6. Collect the user's decision
-
-Wait for explicit per-change accept/reject. Do not apply anything before confirmation. If the user accepts a change the gate marked ❌ conflict, warn once and require re-confirmation.
-
-### 7. Apply
-
-For each **accepted** change: edit `my_checks.xml` to add/modify exactly that module/property, matching the upstream form. Preserve our existing deviations and comments (never clobber a customized regex/message with the upstream default unless the user explicitly accepted that too).
-
-For each **rejected** change: leave an XML comment in `my_checks.xml` at the relevant module documenting the deviation, so the next review knows it was a deliberate choice, not an oversight:
-
-```xml
-<!-- DEVIATION from google_checks.xml (reviewed {date}, PR #{n}):
-     upstream {what changed}. Not adopted — {reason}. -->
-```
-
-Use the PR's creation date for `{date}` and the PR number for `{n}`. Place the comment immediately above the affected module (or where the module would go, for a rejected new module).
-
-### 8. Verify
-
-After applying, run `./mvnw checkstyle:check -B` to confirm the config still parses and the codebase still passes. Report pass/fail with counts. If it fails, show the violations and stop — do not "fix" by loosening a just-accepted rule without telling the user.
+See `.claude/tech/{backend}/templates/checkstyle/upstream-review-procedure.md` for the full procedure.
 
 ## Output
 

--- a/.claude/skills/continue/SKILL.md
+++ b/.claude/skills/continue/SKILL.md
@@ -5,22 +5,25 @@ description: Continue working on a story or task by reading progress.md, executi
 
 # /continue - Resume Development
 
-## Workflow
+Central dispatcher: read `progress.md`, execute the next single work unit, update progress, commit, then STOP. All workflow sequences, progress tracking rules, adapter discovery, and task types are defined in `.claude/rules/workflow.md`. Progress file format examples are in `.claude/templates/workflow/progress-format.md`.
 
-1. **Identify work item** from argument
-2. **Backlog promotion** -- if the story row is in the **Backlog** table in `ProductSpecification/stories.md`, move it to **In Progress** before proceeding
-3. **Read progress** file, bootstrap if missing (stories only) — bootstrapping also surfaces any `tests/extended/*_Extended.md` cases as `[S]` entries (see `workflow.md` → Bootstrapping, step 7); `/continue` never executes them
-4. **Find next step** -- first `[~]` or `[ ]` entry
-5. **Read journey context** -- read `carryover.md` (story root, if it exists) and the current scenario's summary file (`summaries/{scenario-slug}.md`, if it exists). Treat both as additional context for the work unit -- they preserve predictions, decisions, surprises, and quirks from prior conversations. `/continue` only READS these files; it never writes them (the `/handoff` skill is the sole writer).
-6. **Load ADR context** -- check for `decisions/*-decision.md` files in the story directory. If any exist AND the current step references the ADR (via "see ADR" annotation or matching scenario), read it. ADRs contain architectural decisions, schema changes, edge cases, and implementation guidance that the work unit needs.
-7. **Execute one work unit** -- dispatch sub-skills per tables below
-8. **Adapter discovery** -- when the next step is `[ ] adapters-discovery`, read usecase constructor to identify ports and map to adapters (see `workflow.md`). Mark `[x] adapters-discovery`, insert concrete steps below it, commit progress.md.
-9. **Update progress** -- mark completed, advance next, commit
-10. **Update stories.md** -- for stories only, update the phase columns in `ProductSpecification/stories.md` (see below)
+See `.claude/templates/workflow/continue-dispatch.md` for the dispatch tables, pre-commit checklist, and stories.md update rules.
+
+## Algorithm
+
+1. **Identify work item** from argument (see Resolving the Argument).
+2. **Backlog promotion** -- if the story row is in the **Backlog** table in `ProductSpecification/stories.md`, move it to **In Progress** before proceeding.
+3. **Read progress** file, bootstrap if missing (stories only) — bootstrapping also surfaces any `tests/extended/*_Extended.md` cases as `[S]` entries (see `workflow.md` → Bootstrapping, step 7); `/continue` never executes them.
+4. **Find next step** -- first `[~]` or `[ ]` entry.
+5. **Read journey context** -- read `carryover.md` (story root, if it exists) and the current scenario's summary file (`summaries/{scenario-slug}.md`, if it exists) as additional context. `/continue` only READS these files (the `/handoff` skill is the sole writer).
+6. **Load ADR context** -- check for `decisions/*-decision.md` in the story directory; if any exist AND the current step references the ADR, read it for schema changes, edge cases, and implementation guidance.
+7. **Execute one work unit** -- dispatch sub-skills per the dispatch tables in the reference template. Within the work unit, never pause between sub-skills.
+8. **Adapter discovery** -- when the next step is `[ ] adapters-discovery`, read the usecase constructor to identify ports and map to adapters (see `workflow.md`). Mark `[x] adapters-discovery`, insert concrete steps below it, commit progress.md.
+9. **Update progress** -- mark completed, advance next.
+10. **Update stories.md** -- for stories only, update the phase columns in `ProductSpecification/stories.md` (per the reference template) and include it in the same commit.
 10a. **Story Completion Gate** -- for stories only, when the work unit just completed was the story's **final** scenario (every other checkbox is `[x]`/`[S]`), do NOT move the row to Done yet. **STOP** and run the Story Completion Gate (see `workflow.md` → "Story Completion Gate"): surface every `tests/extended/*_Extended.md` case and every `Open` item in the story's `improvements.md`, each with a one-line promote/defer recommendation, and **ask the user to decide per item**. The agent never auto-promotes or auto-closes — it moves the row to Done only after the user has decided every item and any promoted scenarios are appended to `progress.md`. This is a deliberate exception to the "never pause within a work unit" rule.
-11. **Task completion** -- after updating progress, if ALL checkboxes are `[x]` or `[S]` (no `[ ]` or `[~]` remaining), move the task folder to `ProductSpecification/tasks/done/` and include the move in the commit
-
-All workflow sequences, progress tracking rules, adapter discovery procedure, and task types are defined in `.claude/rules/workflow.md`. Progress file format examples are in `.claude/templates/workflow/progress-format.md`.
+11. **Task completion** -- after updating progress, if ALL checkboxes are `[x]` or `[S]`, move the task folder to `ProductSpecification/tasks/done/` and include the move in the commit.
+12. **Commit, then STOP.** Always commit after a work unit (include progress.md). A single `/continue` invocation executes exactly ONE work unit — once the commit lands, stop and report (below). Do NOT read the next `[ ]` step and keep going. If a sub-skill fails, stop immediately and do NOT mark the step complete.
 
 ## Resolving the Argument
 
@@ -36,102 +39,14 @@ All workflow sequences, progress tracking rules, adapter discovery procedure, an
 
 1. **Search branches**: `git branch -a --list "*N*"` (or `git branch -a | grep N`) — look for a `task/N-*` branch, local or remote (run `git fetch` first if remote branches may be stale).
 2. **Search history**: `git log --all --oneline --grep "Task N"` and `git log --all -- "ProductSpecification/tasks/N-*"` — the folder may exist on an unmerged branch.
-3. **If a task branch exists**: report it to the user and switch to it (after confirming the working tree is clean), then resume the normal workflow — read its `progress.md` and execute the next work unit.
+3. **If a task branch exists**: report it to the user and switch to it (after confirming the working tree is clean), then resume the normal workflow.
 4. **Only if neither a folder nor a branch nor history mentions task N**: check the GitHub issue #N; if it exists, offer to bootstrap the task from it via `/task` (reusing the issue, never opening a duplicate). Do not silently create a new task without this git search first.
-
-## Work Unit Dispatch
-
-Each progress.md checkbox maps to sub-skills. Dispatch per `workflow.md` sequences. **This table applies equally to stories AND tasks — never skip `/test-review` or `/refactor` for task steps.**
-
-| Checkbox | Sub-skills |
-|----------|-----------|
-| Spec items (`interview`, `story`, `mockups`, `api-spec`, `test-spec`) | `/{item}` then commit |
-| `design` | `/design-preview` → user approves (optionally with ADR) or `/architecture` → commit (if ADR produced) |
-| `red-*` (acceptance, usecase, domain, adapter, playwright, frontend, frontend-api) | `red-agent.md` → `/test-review` → `/refactor` → commit |
-| `green-usecase`, `green-domain`, `green-adapter X` | `green-agent.md` → `/refactor` → `/test-coverage {module} --focus` → commit |
-| `adapters-discovery` | Load `.claude/templates/workflow/adapter-discovery-checklist.md`, run all 3 checks (ports, exceptions, response shape), mark `[x] adapters-discovery`, insert concrete `red-adapter X` / `green-adapter X` steps (or `[S]`) → commit progress.md |
-| `green-acceptance` | Run inline (no subagent): ensure the shared test DB is up (see `.claude/tech/java-spring/infrastructure.md` → "Test Database"), read `green-agent.md` workflow, load acceptance implementation template, enable the disabled test (remove disable marker — only allowed test change), run acceptance tests, verify GREEN → commit |
-| `green-frontend`, `green-frontend-api` | `green-agent.md` → `/refactor` → commit |
-| `green-playwright` | `/run-backend` → `/run-frontend` → `green-agent.md` (remove-marker-only: no production code, no Statements changes, no backend changes — if test fails, STOP and report) → commit |
-| `align-design` | Build component → `/align-design` → `/design-review` (MANDATORY) → `/refactor` → `/align-design` verify-only → `/test-coverage frontend --focus` → commit |
-| `demo` | `/demo {scenario_test_class}` then progress-only commit |
-| `refactor usecase` / `refactor (...)` | Apply change then run affected tests then commit |
 
 ## Stop and Report
 
-STOP after every commit. A single `/continue` invocation executes exactly ONE work unit. Within that work unit, don't pause between sub-skills. But once the commit lands, stop immediately and report: completed step, test results (pass/fail counts from every test run in the work unit), next step, progress fraction, how to continue. Do NOT read the next `[ ]` step and keep going.
-
-**Test results:** Collect pass/fail counts from every sub-skill that runs tests (red-agent, green-agent, test-coverage, refactor). Include them in the final report as a summary line, e.g., `Tests: 15 passed, 0 failed` or `Tests: 14 passed, 1 failed`. When multiple test suites ran, report each separately.
-
-## Pre-Commit Checklist
-
-Before committing, verify: (1) primary skill ran, (2) `/test-review` ran (red phases), (3) `/refactor` ran (all phases except `green-acceptance`/`green-playwright`/`demo`/spec items), (4) static analysis passes, (5) IDE inspections pass on changed files. If `/refactor` was skipped -- run it before committing.
-
-**Static analysis** (step 4): run the checker for each stack the work unit touched — do NOT skip this step, it catches issues the agents don't check.
-- **Backend files changed** (`.java`): `./mvnw checkstyle:check -pl . -q && ./mvnw pmd:check -pl . -q` — catches missing Javadoc, PMD violations.
-- **Frontend files changed** (`frontend/**`): `npm run lint` from `frontend/` (`eslint . && prettier --check .`) — the same gate as the CI "Frontend Lint" job. Auto-fix with `npm run lint:fix`, then re-run `npm run lint` to confirm clean. See `.claude/tech/vue-ts/infrastructure.md` → "Static Analysis (Pre-Commit)".
-
-Run whichever apply to the files in this work unit; run both when it touched both stacks. If violations are found, fix them before committing.
-
-**IDE inspections** (step 5): for each non-spec file created or modified in this work unit, call the IntelliJ MCP tool `mcp__idea__get_file_problems` (`errorsOnly: false`, pass `projectPath`). It catches issues the static analyzers miss (e.g. `AutoCloseable` used without try-with-resources, redundant code). Fix real findings; for an intentional false positive add a narrowly-scoped `@SuppressWarnings("<id>")` with a comment explaining why. Skip only when the IDEA MCP server is unavailable (e.g. headless/cron runs) — then note it was skipped. Applies to code files only, not markdown/spec.
-
-## Sub-Skill Dispatch
-
-ALL sub-skills dispatch via Agent tool for context isolation:
-
-| Sub-skill | Dispatch method |
-|-----------|----------------|
-| `red-*` | `Agent tool` (subagent_type: `red-agent`) — pass layer, story folder path, scenario name, and ADR content (if loaded) |
-| `green-*` (except `green-acceptance`) | `Agent tool` (subagent_type: `green-agent`) — pass layer, story folder path, scenario name, and ADR content (if loaded) |
-| `green-acceptance` | **Inline** — no subagent. Main agent ensures the shared test DB is up (tech binding → "Test Database"), reads `green-agent.md`, loads acceptance template, enables the test, runs it. Full visibility for user. |
-| `/refactor` | `Agent tool` (subagent_type: `refactor-agent`) |
-| `/test-review` | `Agent tool` (subagent_type: `test-review-agent`) |
-| `/test-coverage` | `Agent tool` (subagent_type: `coverage-agent`) |
-
-Derive the layer from the checkbox (e.g., `red-adapter db` → layer `db`, `green-usecase` → layer `usecase`). Both red-agent and green-agent receive: layer, story folder path, scenario name, and ADR content (if loaded in step 6). The agent resolves test files and templates from its own workflow.
-
-**CHAINING: After each sub-step completes (Agent tool return), echo a 1-2 line status summary (agent name, outcome, pass/fail counts) to the user, then immediately dispatch the next sub-step. Do NOT wait for user input between sub-steps — the echo is informational only.**
-
-**AGENT LOG: Before the first agent dispatch, clear the log: `> infrastructure/agent-progress.log`. After the final commit, include the log contents in the stop-and-report summary.**
-
-**LOG REMINDER: Every time you dispatch a sub-agent (Agent tool call), output this line immediately before the call:**
-```
-> Dispatching {agent-name}. Live progress: tail -f infrastructure/agent-progress.log
-```
-**This reminds the user where to watch. The line appears in conversation output before the agent starts, so the user can open a terminal and tail the log while the agent works.**
-
-## Rules
-
-- Execute exactly ONE work unit per invocation — a work unit includes ALL sub-skills through the commit. Never stop between sub-skills.
-- Always commit after a work unit (include progress.md in the commit)
-- Task commit prefix: `task:` (e.g., `task: red-adapter db (Task 1, Step 1)`)
-- If a sub-skill fails, stop immediately -- do NOT mark the step complete
-- Mandatory sub-skills per phase: see `workflow.md` sequences
-
-## Updating stories.md
-
-After updating `progress.md` for a **story** (not tasks), update the story's row in `ProductSpecification/stories.md` to reflect current phase status. The file has columns: `Spec | Backend | Integration | Frontend | Security | Load | Infra | Status`.
-
-**Phase column values** — derive from `progress.md` sections:
-- `✅` — all checkboxes in that section are `[x]` or `[S]`
-- `🔧` — section has at least one `[~]` or `[ ]` checkbox (work in progress or next up within the current active lifecycle phase)
-- `—` — section exists but no work started yet (all `[ ]`)
-- `n/a` — phase not applicable (test spec file says "No tests" or story has no scenarios for that phase)
-- `·` — no story folder or no progress file exists
-
-**Tests and % columns** — recount after every progress.md update:
-- **Total** = number of `### ` scenario headings in progress.md (not `## ` section headers)
-- **Done** = scenarios where ALL checkboxes are `[x]` or `[S]` (no `[ ]` or `[~]` remaining)
-- **%** = `round(done / total * 100)`
-- Format: `done/total` in Tests column, `N%` in % column
-- Do NOT add a Total row — it causes merge conflicts
-
-**Story completion** — when all scenarios reach 100% (Tests column = `total/total`, % = `100%`), move the story row from the **In Progress** table to the **Done** table in `ProductSpecification/stories.md`. Keep all column values intact.
-
-**When to update**: after every progress.md commit for a story. Include `ProductSpecification/stories.md` in the same commit.
-
-**Lifecycle ordering**: Spec → Backend → Integration → Frontend → Security → Load → Infra. A phase becomes `🔧` when it is the current active phase (has `[~]` items) OR when it still has `[ ]` items and all prior phases are `✅`.
+STOP after every commit. Report: completed step, test results (pass/fail counts from every test run in the work unit — collect from red-agent, green-agent, test-coverage, refactor, e.g. `Tests: 15 passed, 0 failed`; report each suite separately), next step, progress fraction, how to continue. Task commit prefix: `task:` (e.g., `task: red-adapter db (Task 1, Step 1)`). Mandatory sub-skills per phase: see `workflow.md` sequences.
 
 ## Available Templates
 
+- `.claude/templates/workflow/continue-dispatch.md` -- dispatch tables, pre-commit checklist, stories.md update rules
 - `.claude/templates/workflow/progress-format.md` -- progress file format for stories, bug tasks, and refactoring tasks

--- a/.claude/skills/demo/SKILL.md
+++ b/.claude/skills/demo/SKILL.md
@@ -26,58 +26,14 @@ Read `ProductSpecification/technology.md`:
 
 ## Workflow
 
-### 1. Apply Demo Changes
+1. **Apply demo changes** — enable headless video recording + slowMo (Playwright `use` block, or Selenium base-class delay).
+2. **Ensure clean environment** — restart backend fresh, clear email inbox, verify frontend (FE-only scenarios skip backend).
+3. **Run the test** — resolve the argument to a test filter (see table in template), run headless with a generous timeout.
+4. **Surface the recording** — move the produced `video.webm` to a friendly name and report its absolute path.
+5. **Revert all changes (ALWAYS)** — undo the step-1 config edits, pass or fail (the gitignored recording stays).
+6. **Report result** — pass/fail plus the absolute recording path (and error output on failure).
 
-**Playwright stack (`browser-testing: playwright`):** temporarily edit the `use` block in `frontend/playwright.config.ts` to enable video recording and slow the run down. Do **not** add `--headed` or `--start-maximized` — the run stays headless and writes a video file instead:
-
-```ts
-use: {
-  baseURL: appUrl,
-  trace: 'on-first-retry',
-  video: { mode: 'on', size: { width: 1280, height: 720 } },
-  launchOptions: { slowMo: 2000 },
-},
-```
-
-- `video: { mode: 'on', ... }` records every test in the run to `frontend/test-results/<test-dir>/video.webm`. `test-results/` is gitignored, so recordings never pollute the working tree.
-- `slowMo: 2000` adds a 2000ms pause before each action so the steps are clearly visible in the recording (user preference for the recorded flow — the slower pace is fine since it's a file, not a live window).
-- The `.webm` opens in any browser (drag it into a Chrome/Edge tab) or media player. `ffmpeg` is not assumed to be installed, so do not attempt gif conversion unless `ffmpeg -version` succeeds.
-
-**Selenium/Java base-class stack:** enable the framework's video/screen-recording option for the run (do not switch to a visible window); add a 2000ms demo delay constant + method in the Browser statements class and call it at the start of navigation / find-element / find-elements methods.
-
-### 2. Ensure Clean Environment
-
-- Stop any backend you started earlier via the `/stop-backend` skill (never kill Java by name)
-- Clear test email inbox via infrastructure HTTP API
-- Start backend fresh via the `/run-backend` skill (background)
-- Wait for backend to be UP: poll the health endpoint (see backend tech binding → "Health Check")
-- Verify frontend is running (start with `/run-frontend` if not)
-- **FE-only scenarios** (no backend dependency — mocked via `page.route`, or pure UI) skip the backend steps entirely; only the frontend dev server is required.
-
-### 3. Run the Test
-
-Resolve the argument to a test filter using the acceptance test command pattern from Conventions table. Run headless (no `--headed`).
-
-| Argument | Filter |
-|----------|--------|
-| `should_method_name` | Filter to `*.ClassName.should_method_name` (search test files to resolve class) |
-| `ClassName.should_method_name` | Filter to `*.ClassName.should_method_name` |
-| `ClassName` | Filter to `*.ClassName` |
-| *(none)* | Run all frontend acceptance tests |
-
-Delete `frontend/test-results/` before the run so the recording is fresh. Use a generous timeout (180s) since slowMo delays add up.
-
-### 4. Surface the Recording
-
-After the run, locate the produced `video.webm` under `frontend/test-results/<test-dir>/` and **move** it (`mv`, not `cp`) to a friendly, predictable name in the same gitignored directory, e.g. `frontend/test-results/demo-<arg-slug>.webm`, then remove the now-empty `<test-dir>` so only one file remains (copying leaves a duplicate — the original deep-named `video.webm` plus the friendly copy). Report the **absolute path** so the user can open it directly and delete it when satisfied.
-
-### 5. Revert All Changes (ALWAYS)
-
-After the test finishes (pass or fail), revert the config to its original state — undo all changes from step 1 (the `playwright.config.ts` `use` edits, or the base-class/statements changes for the Selenium stack). The recording itself stays (it is gitignored); only the config edits are reverted.
-
-### 6. Report Result
-
-Report whether the test passed or failed and the absolute path to the recording. If it failed, include the error output.
+See `.claude/tech/{browser-testing}/templates/demo/procedure.md` for the full per-step procedure (config edits, clean-environment, run, surface recording, revert).
 
 ## Rules
 

--- a/.claude/skills/design-preview/SKILL.md
+++ b/.claude/skills/design-preview/SKILL.md
@@ -38,37 +38,19 @@ Mark one option as **Recommended** with a one-line rationale ("why this over the
 
 ### 3. Present Options
 
-Show each option as a labelled block: title, summary, pros, cons. Include the recommendation rationale below the recommended option.
-
-**Simple scenarios**: each option in 3-5 lines.
-**Complex scenarios**: each option with method signatures/pseudocode, domain model changes, pipeline/sequence diagrams, port changes.
+Show each option as a labelled block (title, summary, pros, cons) with the recommendation rationale below the recommended one. Depth scales with complexity — see `.claude/templates/workflow/design-preview-formats.md`.
 
 ### 4. Get Option Choice
 
-Ask with `AskUserQuestion`:
-- First answer = the recommended option, label suffixed with "(Recommended)"
-- Other answers = alternative options (one per non-recommended option, up to 3 alternatives)
-- Last answer = "Reject all — escalate to `/architecture`"
-
-Option labels must fit in a chip (12 chars). Keep answer descriptions to one short line.
-
-If user rejects all → invoke `/architecture` and STOP. Do not proceed to the ADR question.
+Ask with `AskUserQuestion`: recommended option first (suffixed "(Recommended)"), then alternatives, last answer "Reject all — escalate to `/architecture`". If user rejects all → invoke `/architecture` and STOP (do not proceed to the ADR question). Answer-layout details: see `.claude/templates/workflow/design-preview-formats.md`.
 
 ### 5. Get ADR Decision
 
-After an option is chosen, ask separately with `AskUserQuestion` whether to capture the decision as an ADR:
-- "Write ADR" — recommended when the user picked a non-recommended option, when the trade-offs are non-obvious, or when downstream scenarios will likely revisit the choice
-- "Skip ADR" — recommended for trivial scenarios (single-option flow) or mechanical choices with no real trade-off
-
-Pick which option to mark "(Recommended)" based on the choice the user just made in step 4.
+After an option is chosen, ask separately with `AskUserQuestion` whether to capture the decision as an ADR ("Write ADR" vs "Skip ADR"). Mark "(Recommended)" based on the choice the user just made in step 4. Recommendation criteria: see `.claude/templates/workflow/design-preview-formats.md`.
 
 ### 6. Completion
 
-| Outcome | Action |
-|---------|--------|
-| Option chosen, no ADR | Mark `design` step as `[x]`. No files created. |
-| Option chosen, write ADR | Mark `design` step as `[x]`, then write an ADR using `.claude/templates/spec/adr-format.md` to the story's `decisions/` subfolder. Pre-populate the ADR's "Rejected" table with the un-chosen options from step 3. Commit includes the ADR file. |
-| Rejected all → `/architecture` | Do NOT mark `design`. `/architecture` runs and decides the ADR. Mark `design` only after the ADR lands. |
+Mark the `design` step per the outcome (no ADR / write ADR / rejected → `/architecture`). See the completion-outcome table in `.claude/templates/workflow/design-preview-formats.md`.
 
 ## Rules
 

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -20,52 +20,11 @@ Research, API discoveries, and architectural findings get lost across conversati
 
 ## Workflow
 
-### Round 1: What and Where
+Three rounds — full procedure in `.claude/templates/documentation/doc-workflow.md`:
 
-**Gather from user:**
-
-1. **What are we documenting?** Summarize the findings in 1-2 sentences. If the current conversation already contains research/findings, extract the summary automatically and confirm with the user.
-
-2. **Where should it live?** Propose a location based on the topic:
-   - Existing folder (e.g., `api-reference/`) → add a new `.md` file or append to existing
-   - New folder under `ProductSpecification/` → create `{topic-slug}/README.md`
-   - Inside a task folder (e.g., `tasks/35-bug-.../research.md`) → already scoped
-
-   **Decision aid:** If the findings are specific to one task/story, keep them in that folder. If they're reusable across multiple stories or tasks, create a shared location.
-
-3. **Filename:** Propose based on content (e.g., `research.md`, `README.md`, `{topic}.md`). Confirm with user.
-
-### Round 2: Cross-References
-
-**Identify automatically, confirm with user:**
-
-1. **What should reference this doc?** (inbound links)
-   - Search for related story `endpoints.md` files, task `spec.md` files, and `CLAUDE.md` that would benefit from a link to this document.
-   - Use `Grep` to find files mentioning the key concepts being documented.
-   - Propose specific files and the line/section where the link should be added.
-
-2. **What should this doc reference?** (outbound links)
-   - Scan the conversation for source materials: story interviews, task specs, external URLs, code files.
-   - Search `ProductSpecification/` for related existing docs.
-   - List proposed references for user confirmation.
-
-Present both lists to the user. They can add/remove entries.
-
-### Round 3: Write and Link
-
-1. **Write the document** with this structure:
-   - Title and summary
-   - Findings organized in tables and sections (prefer tables for structured data)
-   - Links to source materials (outbound references from Round 2)
-   - External URLs where applicable
-
-2. **Update referencing docs** — add links in the files identified in Round 2 (inbound references). Use relative paths. Add links in contextually appropriate sections — don't just append to the end.
-
-3. **Update indexes:**
-   - If a new folder was created → update `ProductSpecification/CLAUDE.md` structure tree
-   - If the doc is in a task folder → no index update needed
-
-4. **Commit** all changes with message: `docs: {short description}`
+1. **Round 1 — What and Where:** summarize the findings; propose location (existing folder, new `{topic-slug}/README.md`, or task folder) and filename; confirm with user.
+2. **Round 2 — Cross-References:** identify inbound links (docs that should reference this) and outbound links (sources this references); confirm both lists with the user.
+3. **Round 3 — Write and Link:** write the doc (title, summary, tables, links), update referencing docs with relative-path links, update indexes if a new folder was created, then commit `docs: {short description}`.
 
 ## Rules
 

--- a/.claude/skills/prompt-update/SKILL.md
+++ b/.claude/skills/prompt-update/SKILL.md
@@ -18,14 +18,7 @@ Classify a piece of new content and write it to the correct file(s) in the proje
 
 1. **Parse input.** If no content provided, ask the user what to add.
 2. **Understand the content.** What does it mean? Is it a principle, a detection pattern, a code example, a workflow step?
-3. **Classify targets** using `.claude/templates/documentation/prompt-update-classification.md`. Walk ALL 4 decision questions explicitly — principle, detection pattern, code example, layer-specific context. Show the classification before writing:
-   ```
-   1. Principle? → frontend-rules.md (new section)
-   2. Detection? → refactor-agent.md (smell table) + scan-checklist.md (A-check)
-   3. Template?  → new templates/refactoring/extract-tailwind-class.md
-   4. Layer-specific? → n/a
-   ```
-   Most updates touch 2+ files. If only one target is identified, double-check — a rule without detection won't be enforced, a detection without a template won't guide the fix.
+3. **Classify targets** using `.claude/templates/documentation/prompt-update-classification.md`. Walk ALL 4 decision questions explicitly — principle, detection pattern, code example, layer-specific context. Show the classification before writing, following the "Classification Output Format" in that template.
 4. **Check for duplication** — grep key terms across `.claude/rules/`, `.claude/tech/`, `.claude/agents/`, `.claude/skills/`, `.claude/templates/`. If a duplicate exists, report it and ask: skip, merge, or replace?
 5. **Write to all target files** in one pass. Match each file's existing style.
 6. **Tech-agnostic gate** — for every write targeting a universal file (`.claude/rules/`, `.claude/templates/`), scan the content you just wrote for tech leaks. See "Tech-Agnostic Verification" in the classification template. If a leak is found, rephrase in universal terms first — only relocate to tech binding when the content is inherently tech-specific.

--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -20,68 +20,24 @@ Default location: `ProductSpecification/stories/*/mockups/`
 
 ### Phase 1: Determine Scope
 
-Parse user input to determine target:
-
-**Folder/file filtering:**
+Parse user input to determine target. Folder/file filtering:
 - `/screenshot` — All mockups in default location
 - `/screenshot login.html` — Single file
 - `/screenshot 01_auth` — Files matching pattern
 
 ### Phase 2: Ensure Puppeteer Environment
 
-The centralized Puppeteer runner is in `.screenshots-temp/`:
-
-1. Check if `.screenshots-temp/node_modules` exists:
-   - If not: run `cd .screenshots-temp && npm install`
-2. This only needs to happen once, not per-mockup-directory
+Ensure `.screenshots-temp/node_modules` exists (install once if not).
 
 ### Phase 3: Run Screenshot Script
 
-Execute from the centralized location:
-
-```bash
-cd .screenshots-temp && node take-screenshots.js [target]
-```
-
-**Examples:**
-```bash
-# All mockups in default directory
-cd .screenshots-temp && node take-screenshots.js
-
-# Specific file (relative to repo root)
-cd .screenshots-temp && node take-screenshots.js ../ProductSpecification/stories/01-create-task/mockups/desktop/create-task.html
-
-# Directory with HTML files
-cd .screenshots-temp && node take-screenshots.js ../ProductSpecification/stories/01-create-task/mockups/desktop/
-
-# Filter by filename pattern
-cd .screenshots-temp && node take-screenshots.js ../ProductSpecification/stories/01-create-task/mockups/ mobile
-```
+Run `take-screenshots.js` from `.screenshots-temp/` against the target.
 
 ### Phase 4: Output Summary
 
-Report to user:
-- Number of screenshots taken
-- Output location (screenshots saved alongside HTML files or in `screenshots/` subfolder)
-- Any failures encountered
+Report screenshots taken, output location, and any failures.
 
-## Example Invocations
-
-```
-/screenshot                           # All mockups
-/screenshot login.html                # Specific file
-/screenshot mobile                    # Files containing "mobile"
-```
-
-## Design Constraints
-
-- **Mobile detection**: Files in a `mobile/` parent directory use mobile viewport (390x844)
-- **Desktop viewport**: 1400x900
-- **Element selector**: Crop to `.mockup-card` element when present
-- **Fallback**: Full page screenshot if `.mockup-card` not found
-- **Format**: PNG
-- **Output**: `screenshots/` subfolder next to each HTML file (per-directory, not centralized)
-- **Skip**: `node_modules/`, `screenshots/`, and `screenshots-live/` directories
+See `.claude/tech/{browser-testing}/templates/screenshot/runner.md` for the runner environment, commands, examples, and design constraints.
 
 ## Notes
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -19,14 +19,12 @@ If no arguments, ask interactively: type and short title (2-5 words).
 
 ### 2. Allocate the Task Number via a GitHub Issue
 
-**The task number IS the GitHub issue number.** Issue numbers are allocated atomically and globally by GitHub, so parallel task creation across worktrees/branches can never collide. (The old "max existing folder + 1" scheme raced: each branch only sees its own committed folders, so two parallel branches both pick the same next number — exactly the `14`/`14` clash that motivated this change, #141.) Every task — `bug` AND `refactoring` — gets an issue.
+**The task number IS the GitHub issue number** (atomic, collision-free across worktrees). Rationale and the legacy 1–14 note: `.claude/templates/task/creation-formats.md`. Every task — `bug` AND `refactoring` — gets an issue.
 
 1. Resolve the repository from `git remote get-url origin` (e.g. `is-ivanov/rpm-ddd`).
 2. **If an issue already exists** for this work (the user passed one, or you are bootstrapping from an existing issue), use its number — do not open a duplicate.
 3. **Otherwise create the issue** with the **GitHub MCP server** (`issue_write`, `method: create`) — title from the task title, body from the gathered Problem + Solution (+ Reproduction for bugs), `labels: ["bug"]` for bugs / `["enhancement"]` for refactorings. Fall back to `gh issue create` only if the MCP server is unavailable.
 4. Capture the returned issue **number** `N`. This is the task number used everywhere below.
-
-> Legacy tasks 1–14 used the old sequential scheme and keep their numbers. Issue numbers are already far above that range (140s+), so a new issue-numbered folder never clashes with a legacy one.
 
 ### 3. Create Folder
 
@@ -44,7 +42,7 @@ Gather from user:
 
 ### 5. Generate spec.md
 
-Write `ProductSpecification/tasks/{N}-{type}-{slug}/spec.md` using the format in `.claude/templates/task/creation-formats.md`. Include the `Issue: #N` line — every task has one, and the number matches the folder. Every test written during a **bug** task's TDD cycle carries this number (per tech binding `tdd.md`); refactoring tasks record the issue for traceability but do not tag tests.
+Write `ProductSpecification/tasks/{N}-{type}-{slug}/spec.md` using the format in `.claude/templates/task/creation-formats.md` (includes the `Issue: #N` line and its bug-test-tagging vs refactoring-traceability note).
 
 ### 6. Generate progress.md
 
@@ -68,7 +66,4 @@ Show spec.md and progress.md to user for review. Commit both files.
 - Task number = GitHub issue number (globally atomic — no parallel-creation collisions). Legacy tasks 1–14 keep their old sequential numbers.
 - Slug uses lowercase-hyphenated title (max 5 words)
 - Commit message: `task: spec (Task {N}, {title})`
-
-## Templates
-
-- `.claude/templates/task/creation-formats.md` -- spec.md format, progress.md formats
+- Formats (spec.md, progress.md, usage examples, task-number rationale): `.claude/templates/task/creation-formats.md`

--- a/.claude/tech/java-spring/templates/checkstyle/upstream-review-procedure.md
+++ b/.claude/tech/java-spring/templates/checkstyle/upstream-review-procedure.md
@@ -1,0 +1,73 @@
+# Checkstyle Upstream Update Review — Full Procedure
+
+This is the full step-by-step procedure for the `checkstyle-review` skill. The skill keeps a compact one-line summary of each step and links here for the detail.
+
+## Procedure
+
+### 1. Get the upstream diff
+
+Fetch the PR diff (GitHub MCP `pull_request_read` method `get_diff`). It contains only `google_checks.xml`. Split it into **logical changes** — group hunks that belong to one module/concern together (e.g. adding an `id` plus a new sibling `<module>` is one logical change, not two).
+
+### 2. Map each change to my_checks.xml
+
+Read `code-quality-config/checkstyle/my_checks.xml`. For each logical change determine:
+
+- **Present** — the same module/check exists in `my_checks.xml` (the change is portable and relevant).
+- **Absent** — the affected module isn't in our config (we already diverged or never adopted it; the change usually doesn't apply — note it but default to no-op).
+- **New module** — upstream adds a brand-new check we don't have.
+
+Quote the relevant `my_checks.xml` line range for each Present/New change.
+
+### 3. Classify each change
+
+- **Bugfix** — corrects a wrong regex/anchor/token (e.g. anchoring a `checkFormat` to a fully-qualified suffix). Low risk.
+- **Coverage** — extends an existing check to more tokens/cases (e.g. adding `LITERAL_DEFAULT` to a curly-brace rule). Behavioral — may newly flag existing code.
+- **Style opinion** — a new stylistic rule (e.g. forbidding decorative banner comments). Judge against this repo's own conventions (`AGENTS.md`, `.claude/rules/`).
+- **Cosmetic** — `id` attributes added purely so rules can be targeted by suppressions. Always safe.
+- **Version-incompatible** — the upstream rule uses a token or property our pinned checkstyle version doesn't accept yet (upstream tracks checkstyle *master*; our `checkstyle.version` lags). Surfaces as a config-load error (`Token "X" was not found in Acceptable tokens list`, `Property 'Y' does not exist`), not a style violation. Verdict: **reject / defer until checkstyle upgrade** — or, if the rule is wanted, bundle it with a `checkstyle.version` bump and re-gate. The formatter gate (step 4) catches these, since `checkstyle:check` fails to even load the config.
+
+### 4. Formatter-conflict gate (MANDATORY for layout checks)
+
+Java formatting in this repo is enforced by **Spotless + Palantir Java Format** (`./mvnw spotless:apply`). A checkstyle rule that governs **layout** can fight the formatter: the formatter produces one layout, checkstyle then rejects it → unfixable build.
+
+A change is **layout-related** if its module is any of: `*Wrap` (Operator/Separator), `*Curly` (Left/Right), `Indentation`, `WhitespaceAround`/`WhitespaceAfter`/`NoWhitespace*`/`GenericWhitespace`, `ParenPad`/`MethodParamPad`, `EmptyLineSeparator`, `AnnotationLocation`, `CommentsIndentation`, `NoLineWrap`. Naming, Javadoc, import-order, and Todo/comment-content checks are **not** layout-related — skip the gate for them.
+
+**Gate against the checkstyle version the BUILD uses — not whatever the PR branch pins.** The monthly PR branch is often cut from a *stale* base and carries an older `checkstyle.version` in its `pom.xml`. Running the gate with that stale version gives wrong verdicts: a rule using a token only added in a newer checkstyle will *falsely* look incompatible, and vice-versa. Before gating, read `checkstyle.version` from the **target branch** (`main`) `pom.xml` — that is the version `./mvnw verify` actually runs. If the worktree/PR-branch pins a different version, override every gate run with `-Dcheckstyle.version=<target-version>` (or rebase the PR branch onto `main` first). Always record which version the verdict was produced against.
+
+For each layout-related candidate, **verify before recommending accept**:
+
+1. On a scratch branch / stash-safe working tree, apply that single change to `my_checks.xml`.
+2. Run `./mvnw spotless:apply -q` (re-formats sources to Palantir's canonical layout — no-op if already clean).
+3. Run `./mvnw checkstyle:check -B -Dcheckstyle.version=<target-version>`.
+4. Interpret the result:
+   - **Config fails to load** (`Token "X" was not found in Acceptable tokens list`, unknown property) → **Version-incompatible** (see step 3). Not a formatter verdict — reject/defer or bundle a version bump. A failed load aborts *all* candidates in that run, so re-isolate: drop the incompatible change and re-gate the rest.
+   - **Checkstyle reports violations on formatter-owned layout** → **conflict**: the rule contradicts Palantir. Recommend **reject** (or defer) and record the conflicting message.
+   - **Clean (exit 0) and `git diff --stat` shows spotless reformatted nothing** → no conflict, safe to accept on merit. (If spotless *did* reformat sources, the new layout the formatter produced still passes checkstyle — also fine — but note it: a future PR will carry that reformat.)
+5. Revert the scratch change before moving on (each candidate is tested in isolation; final application happens in step 7). To save maven runs you may gate all layout candidates together first; only isolate when the combined run fails, to attribute the failure.
+
+Note known historical conflicts already documented in `my_checks.xml` (e.g. `TextBlockGoogleStyleFormatting`, Indentation block disabled) — if a change touches an already-disabled-for-Palantir area, flag it and default to reject.
+
+### 5. Present the review
+
+Show one table: change # | summary | present in my_checks (line range) | classification | gate result (n/a, ✅ clean, ❌ conflict, ⛔ version-incompatible) | recommendation (Accept / Reject / Optional — your call). State the checkstyle version the gate ran against. Below the table, one line per change explaining the reasoning. End by asking the user which changes to accept — they decide; recommendations are advice.
+
+### 6. Collect the user's decision
+
+Wait for explicit per-change accept/reject. Do not apply anything before confirmation. If the user accepts a change the gate marked ❌ conflict, warn once and require re-confirmation.
+
+### 7. Apply
+
+For each **accepted** change: edit `my_checks.xml` to add/modify exactly that module/property, matching the upstream form. Preserve our existing deviations and comments (never clobber a customized regex/message with the upstream default unless the user explicitly accepted that too).
+
+For each **rejected** change: leave an XML comment in `my_checks.xml` at the relevant module documenting the deviation, so the next review knows it was a deliberate choice, not an oversight:
+
+```xml
+<!-- DEVIATION from google_checks.xml (reviewed {date}, PR #{n}):
+     upstream {what changed}. Not adopted — {reason}. -->
+```
+
+Use the PR's creation date for `{date}` and the PR number for `{n}`. Place the comment immediately above the affected module (or where the module would go, for a rejected new module).
+
+### 8. Verify
+
+After applying, run `./mvnw checkstyle:check -B` to confirm the config still parses and the codebase still passes. Report pass/fail with counts. If it fails, show the violations and stop — do not "fix" by loosening a just-accepted rule without telling the user.

--- a/.claude/tech/java-spring/templates/testing/red-phase-layer-notes.md
+++ b/.claude/tech/java-spring/templates/testing/red-phase-layer-notes.md
@@ -1,0 +1,54 @@
+# Red Phase — Per-Layer Test Notes (java-spring)
+
+Layer-specific RED-phase detail loaded on demand by `red-agent`. Covers the acceptance, domain, and adapter layers, plus reuse checks before writing test infrastructure.
+
+## Acceptance Layer: Running Backend Required
+
+Acceptance tests need a live backend. Predictions must be about feature behavior (see `tdd-rules.md`).
+
+0. Before running the test, ensure the shared test DB is up — see `.claude/tech/java-spring/infrastructure.md` → "Test Database" (idempotent; reused across runs, never stopped). This also applies when running a `db` adapter test (`@Tag("db")`).
+1. Before running the test, ensure the backend is up (`/run-backend` or check health endpoint)
+2. Predict the **actual application-level failure** — assertion error, wrong HTTP status, missing data, etc.
+3. If the feature is already fully implemented and the test would pass, the prediction is "test passes" — skip straight to `green-acceptance` (mark red-usecase/green-usecase/adapters as `[S]` with reason)
+4. If the test fails (new implementation needed), verify that `progress.md` has a `design` step after `red-acceptance`. If missing, add it — `design` is mandatory for every scenario requiring new implementation.
+5. **One action, assert all consequences** (see `tdd-rules.md`). If the scenario adds a new observable consequence (e.g. an email, an event, persisted state) to an action ALREADY covered by an existing acceptance test, **extend that test** with new `then` assertions instead of creating a parallel acceptance class for the same action — Level 1 runs with the full context (DB, SMTP, …) already up, so a second full-context test for the same action is wasted wall-clock.
+
+## Domain Layer: Optional, One Test Class per Domain Class
+
+Domain tests are OPTIONAL — only create when the domain object has testable logic (validation, state transitions, computed fields, business rules). Skip when: the class is a plain data holder with no behavior.
+
+ONE test means **one test class per domain class** (value object, entity, policy, enum). The class may contain multiple test methods (valid cases, invalid cases via parameterized tests).
+
+- Mark **each** test method with the test disable marker (placed per-method, not on the class — see the tech binding's `red-phase-formats.md`)
+- Predict failure for each test method
+- Parameterized tests count as one test method for prediction purposes
+
+## Adapter Layer: Multiple Test Methods
+
+For adapter layers, follow the test pyramid from `TESTING.md`. Each level tests only what is NOT covered by the level above.
+
+**rest adapter** (Level 2 — web slice):
+- ONE test class per controller endpoint that has validation or error-handling logic.
+- **Test**: validation errors (422), business-exception-to-status-code mapping (401, 404, 422).
+- **Do NOT test**: happy path — covered by acceptance tests (Level 1).
+- **Skip `[S]`**: when the endpoint is a simple delegation (controller → usecase → response) with no request validation and no error mapping.
+- Happy-path response shape is verified by the acceptance test.
+
+**db adapter** (infrastructure):
+- Only for custom `@Query`, native SQL, Specifications, JOIN FETCH — see `.claude/tech/java-spring/templates/db/test-class.md`.
+- Simple Spring Data derived queries (`findByXxx`, `existsByXxx`) → `[S]`.
+
+**email / security / other adapters**:
+- Only corner cases not covered by acceptance tests.
+
+- Mark **each** test method with the test disable marker (placed per-method, not on the class — see the tech binding's `red-phase-formats.md`)
+- Predict failure for **each** test method separately
+- Every method must fail as predicted before its marker is added
+
+## Reuse Checks (before writing)
+
+Before creating new test infrastructure, search for existing pieces to reuse:
+
+1. **Existing Statements assertions** — grep all Statements files (including the target file itself) for `assert*` methods covering the same domain concept or response fields (e.g., `status`, `priority`, `createdAt`). Check within the same Statements class first, then across classes. If an existing method already asserts the same fields, delegate to it and add only the scenario-specific assertions on top.
+2. **Existing Fakes** — grep `fake/` for Fakes with the same structure. If structurally identical, extract a shared base class immediately rather than copy-pasting.
+3. **Existing `@WebApi` classes (acceptance + rest layers)** — before creating a new `@WebApi`-annotated `AbstractApi` subclass, grep `fixtures/` packages for existing API classes targeting the same controller (search for the controller's `BASE_URI` or path prefix). If found → add the new endpoint method to the existing class. If not found → create a new `@WebApi` class. This applies to both acceptance tests (integration tests) and REST adapter tests (web slice tests).

--- a/.claude/tech/playwright/templates/demo/procedure.md
+++ b/.claude/tech/playwright/templates/demo/procedure.md
@@ -1,0 +1,56 @@
+# /demo — Full Per-Step Procedure (Playwright / Selenium)
+
+The full per-step procedure for the `/demo` skill. Resolve the `browser-testing` concern (config file, run command) and the `backend` concern (run/stop/health) from `ProductSpecification/technology.md` before starting.
+
+## 1. Apply Demo Changes
+
+**Playwright stack (`browser-testing: playwright`):** temporarily edit the `use` block in `frontend/playwright.config.ts` to enable video recording and slow the run down. Do **not** add `--headed` or `--start-maximized` — the run stays headless and writes a video file instead:
+
+```ts
+use: {
+  baseURL: appUrl,
+  trace: 'on-first-retry',
+  video: { mode: 'on', size: { width: 1280, height: 720 } },
+  launchOptions: { slowMo: 2000 },
+},
+```
+
+- `video: { mode: 'on', ... }` records every test in the run to `frontend/test-results/<test-dir>/video.webm`. `test-results/` is gitignored, so recordings never pollute the working tree.
+- `slowMo: 2000` adds a 2000ms pause before each action so the steps are clearly visible in the recording (user preference for the recorded flow — the slower pace is fine since it's a file, not a live window).
+- The `.webm` opens in any browser (drag it into a Chrome/Edge tab) or media player. `ffmpeg` is not assumed to be installed, so do not attempt gif conversion unless `ffmpeg -version` succeeds.
+
+**Selenium/Java base-class stack:** enable the framework's video/screen-recording option for the run (do not switch to a visible window); add a 2000ms demo delay constant + method in the Browser statements class and call it at the start of navigation / find-element / find-elements methods.
+
+## 2. Ensure Clean Environment
+
+- Stop any backend you started earlier via the `/stop-backend` skill (never kill Java by name)
+- Clear test email inbox via infrastructure HTTP API
+- Start backend fresh via the `/run-backend` skill (background)
+- Wait for backend to be UP: poll the health endpoint (see backend tech binding → "Health Check")
+- Verify frontend is running (start with `/run-frontend` if not)
+- **FE-only scenarios** (no backend dependency — mocked via `page.route`, or pure UI) skip the backend steps entirely; only the frontend dev server is required.
+
+## 3. Run the Test
+
+Resolve the argument to a test filter using the acceptance test command pattern from Conventions table. Run headless (no `--headed`).
+
+| Argument | Filter |
+|----------|--------|
+| `should_method_name` | Filter to `*.ClassName.should_method_name` (search test files to resolve class) |
+| `ClassName.should_method_name` | Filter to `*.ClassName.should_method_name` |
+| `ClassName` | Filter to `*.ClassName` |
+| *(none)* | Run all frontend acceptance tests |
+
+Delete `frontend/test-results/` before the run so the recording is fresh. Use a generous timeout (180s) since slowMo delays add up.
+
+## 4. Surface the Recording
+
+After the run, locate the produced `video.webm` under `frontend/test-results/<test-dir>/` and **move** it (`mv`, not `cp`) to a friendly, predictable name in the same gitignored directory, e.g. `frontend/test-results/demo-<arg-slug>.webm`, then remove the now-empty `<test-dir>` so only one file remains (copying leaves a duplicate — the original deep-named `video.webm` plus the friendly copy). Report the **absolute path** so the user can open it directly and delete it when satisfied.
+
+## 5. Revert All Changes (ALWAYS)
+
+After the test finishes (pass or fail), revert the config to its original state — undo all changes from step 1 (the `playwright.config.ts` `use` edits, or the base-class/statements changes for the Selenium stack). The recording itself stays (it is gitignored); only the config edits are reverted.
+
+## 6. Report Result
+
+Report whether the test passed or failed and the absolute path to the recording. If it failed, include the error output.

--- a/.claude/tech/playwright/templates/screenshot/runner.md
+++ b/.claude/tech/playwright/templates/screenshot/runner.md
@@ -1,0 +1,52 @@
+# Screenshot Runner (Puppeteer)
+
+The centralized Puppeteer runner lives in `.screenshots-temp/` and is driven by `node take-screenshots.js`. This file holds the runner environment, commands, examples, and design constraints for the `/screenshot` skill.
+
+### Phase 2: Ensure Puppeteer Environment
+
+The centralized Puppeteer runner is in `.screenshots-temp/`:
+
+1. Check if `.screenshots-temp/node_modules` exists:
+   - If not: run `cd .screenshots-temp && npm install`
+2. This only needs to happen once, not per-mockup-directory
+
+### Phase 3: Run Screenshot Script
+
+Execute from the centralized location:
+
+```bash
+cd .screenshots-temp && node take-screenshots.js [target]
+```
+
+**Examples:**
+```bash
+# All mockups in default directory
+cd .screenshots-temp && node take-screenshots.js
+
+# Specific file (relative to repo root)
+cd .screenshots-temp && node take-screenshots.js ../ProductSpecification/stories/01-create-task/mockups/desktop/create-task.html
+
+# Directory with HTML files
+cd .screenshots-temp && node take-screenshots.js ../ProductSpecification/stories/01-create-task/mockups/desktop/
+
+# Filter by filename pattern
+cd .screenshots-temp && node take-screenshots.js ../ProductSpecification/stories/01-create-task/mockups/ mobile
+```
+
+## Example Invocations
+
+```
+/screenshot                           # All mockups
+/screenshot login.html                # Specific file
+/screenshot mobile                    # Files containing "mobile"
+```
+
+## Design Constraints
+
+- **Mobile detection**: Files in a `mobile/` parent directory use mobile viewport (390x844)
+- **Desktop viewport**: 1400x900
+- **Element selector**: Crop to `.mockup-card` element when present
+- **Fallback**: Full page screenshot if `.mockup-card` not found
+- **Format**: PNG
+- **Output**: `screenshots/` subfolder next to each HTML file (per-directory, not centralized)
+- **Skip**: `node_modules/`, `screenshots/`, and `screenshots-live/` directories

--- a/.claude/templates/documentation/doc-workflow.md
+++ b/.claude/templates/documentation/doc-workflow.md
@@ -1,0 +1,50 @@
+# /doc Workflow — Detailed Procedure
+
+The `/doc` skill captures knowledge into `ProductSpecification/` in three rounds.
+
+## Round 1: What and Where
+
+**Gather from user:**
+
+1. **What are we documenting?** Summarize the findings in 1-2 sentences. If the current conversation already contains research/findings, extract the summary automatically and confirm with the user.
+
+2. **Where should it live?** Propose a location based on the topic:
+   - Existing folder (e.g., `api-reference/`) → add a new `.md` file or append to existing
+   - New folder under `ProductSpecification/` → create `{topic-slug}/README.md`
+   - Inside a task folder (e.g., `tasks/35-bug-.../research.md`) → already scoped
+
+   **Decision aid:** If the findings are specific to one task/story, keep them in that folder. If they're reusable across multiple stories or tasks, create a shared location.
+
+3. **Filename:** Propose based on content (e.g., `research.md`, `README.md`, `{topic}.md`). Confirm with user.
+
+## Round 2: Cross-References
+
+**Identify automatically, confirm with user:**
+
+1. **What should reference this doc?** (inbound links)
+   - Search for related story `endpoints.md` files, task `spec.md` files, and `CLAUDE.md` that would benefit from a link to this document.
+   - Use `Grep` to find files mentioning the key concepts being documented.
+   - Propose specific files and the line/section where the link should be added.
+
+2. **What should this doc reference?** (outbound links)
+   - Scan the conversation for source materials: story interviews, task specs, external URLs, code files.
+   - Search `ProductSpecification/` for related existing docs.
+   - List proposed references for user confirmation.
+
+Present both lists to the user. They can add/remove entries.
+
+## Round 3: Write and Link
+
+1. **Write the document** with this structure:
+   - Title and summary
+   - Findings organized in tables and sections (prefer tables for structured data)
+   - Links to source materials (outbound references from Round 2)
+   - External URLs where applicable
+
+2. **Update referencing docs** — add links in the files identified in Round 2 (inbound references). Use relative paths. Add links in contextually appropriate sections — don't just append to the end.
+
+3. **Update indexes:**
+   - If a new folder was created → update `ProductSpecification/CLAUDE.md` structure tree
+   - If the doc is in a task folder → no index update needed
+
+4. **Commit** all changes with message: `docs: {short description}`

--- a/.claude/templates/documentation/prompt-update-classification.md
+++ b/.claude/templates/documentation/prompt-update-classification.md
@@ -10,6 +10,19 @@ Writing style by layer:
 - **Templates**: Fenced code blocks with BAD/GOOD labels, numbered rules, tables
 - **Skills**: Only layer-specific context unique to one adapter/layer
 
+## Classification Output Format
+
+Before writing, show the classification — walk all 4 decision questions explicitly, e.g.:
+
+```
+1. Principle? → frontend-rules.md (new section)
+2. Detection? → refactor-agent.md (smell table) + scan-checklist.md (A-check)
+3. Template?  → new templates/refactoring/extract-tailwind-class.md
+4. Layer-specific? → n/a
+```
+
+Most updates touch 2+ files. If only one target is identified, double-check — a rule without detection won't be enforced, a detection without a template won't guide the fix.
+
 ## Decision Process
 
 For each piece of content, ask:

--- a/.claude/templates/task/creation-formats.md
+++ b/.claude/templates/task/creation-formats.md
@@ -14,7 +14,7 @@
 # Task {N}: {Title}
 
 Type: {bug|refactoring}
-Issue: #{N}  <- every task (the task number IS the issue number); bug tests are tagged with it, refactoring records it for traceability
+Issue: #{N}  <- every task (the task number IS the issue number; number matches the folder); bug tests are tagged with it (per tech binding `tdd.md`), refactoring records it for traceability but does not tag tests
 
 ## Problem
 
@@ -32,6 +32,12 @@ Issue: #{N}  <- every task (the task number IS the issue number); bug tests are 
 
 {steps}
 ```
+
+## Task Number = GitHub Issue Number (rationale)
+
+**The task number IS the GitHub issue number.** Issue numbers are allocated atomically and globally by GitHub, so parallel task creation across worktrees/branches can never collide. (The old "max existing folder + 1" scheme raced: each branch only sees its own committed folders, so two parallel branches both pick the same next number — exactly the `14`/`14` clash that motivated this change, #141.) Every task — `bug` AND `refactoring` — gets an issue.
+
+> Legacy tasks 1–14 used the old sequential scheme and keep their numbers. Issue numbers are already far above that range (140s+), so a new issue-numbered folder never clashes with a legacy one.
 
 ## progress.md Formats
 

--- a/.claude/templates/workflow/continue-dispatch.md
+++ b/.claude/templates/workflow/continue-dispatch.md
@@ -1,0 +1,82 @@
+# /continue Dispatch Reference
+
+Reference material for the `/continue` skill: dispatch tables, pre-commit checklist, and stories.md update rules. The skill's algorithm references this file.
+
+## Work Unit Dispatch
+
+Each progress.md checkbox maps to sub-skills. Dispatch per `workflow.md` sequences. **This table applies equally to stories AND tasks — never skip `/test-review` or `/refactor` for task steps.**
+
+| Checkbox | Sub-skills |
+|----------|-----------|
+| Spec items (`interview`, `story`, `mockups`, `api-spec`, `test-spec`) | `/{item}` then commit |
+| `design` | `/design-preview` → user approves (optionally with ADR) or `/architecture` → commit (if ADR produced) |
+| `red-*` (acceptance, usecase, domain, adapter, playwright, frontend, frontend-api) | `red-agent.md` → `/test-review` → `/refactor` → commit |
+| `green-usecase`, `green-domain`, `green-adapter X` | `green-agent.md` → `/refactor` → `/test-coverage {module} --focus` → commit |
+| `adapters-discovery` | Load `.claude/templates/workflow/adapter-discovery-checklist.md`, run all 3 checks (ports, exceptions, response shape), mark `[x] adapters-discovery`, insert concrete `red-adapter X` / `green-adapter X` steps (or `[S]`) → commit progress.md |
+| `green-acceptance` | Run inline (no subagent): ensure the shared test DB is up (see `.claude/tech/java-spring/infrastructure.md` → "Test Database"), read `green-agent.md` workflow, load acceptance implementation template, enable the disabled test (remove disable marker — only allowed test change), run acceptance tests, verify GREEN → commit |
+| `green-frontend`, `green-frontend-api` | `green-agent.md` → `/refactor` → commit |
+| `green-playwright` | `/run-backend` → `/run-frontend` → `green-agent.md` (remove-marker-only: no production code, no Statements changes, no backend changes — if test fails, STOP and report) → commit |
+| `align-design` | Build component → `/align-design` → `/design-review` (MANDATORY) → `/refactor` → `/align-design` verify-only → `/test-coverage frontend --focus` → commit |
+| `demo` | `/demo {scenario_test_class}` then progress-only commit |
+| `refactor usecase` / `refactor (...)` | Apply change then run affected tests then commit |
+
+## Pre-Commit Checklist
+
+Before committing, verify: (1) primary skill ran, (2) `/test-review` ran (red phases), (3) `/refactor` ran (all phases except `green-acceptance`/`green-playwright`/`demo`/spec items), (4) static analysis passes, (5) IDE inspections pass on changed files. If `/refactor` was skipped -- run it before committing.
+
+**Static analysis** (step 4): run the checker for each stack the work unit touched — do NOT skip this step, it catches issues the agents don't check.
+- **Backend files changed** (`.java`): `./mvnw checkstyle:check -pl . -q && ./mvnw pmd:check -pl . -q` — catches missing Javadoc, PMD violations.
+- **Frontend files changed** (`frontend/**`): `npm run lint` from `frontend/` (`eslint . && prettier --check .`) — the same gate as the CI "Frontend Lint" job. Auto-fix with `npm run lint:fix`, then re-run `npm run lint` to confirm clean. See `.claude/tech/vue-ts/infrastructure.md` → "Static Analysis (Pre-Commit)".
+
+Run whichever apply to the files in this work unit; run both when it touched both stacks. If violations are found, fix them before committing.
+
+**IDE inspections** (step 5): for each non-spec file created or modified in this work unit, call the IntelliJ MCP tool `mcp__idea__get_file_problems` (`errorsOnly: false`, pass `projectPath`). It catches issues the static analyzers miss (e.g. `AutoCloseable` used without try-with-resources, redundant code). Fix real findings; for an intentional false positive add a narrowly-scoped `@SuppressWarnings("<id>")` with a comment explaining why. Skip only when the IDEA MCP server is unavailable (e.g. headless/cron runs) — then note it was skipped. Applies to code files only, not markdown/spec.
+
+## Sub-Skill Dispatch
+
+ALL sub-skills dispatch via Agent tool for context isolation:
+
+| Sub-skill | Dispatch method |
+|-----------|----------------|
+| `red-*` | `Agent tool` (subagent_type: `red-agent`) — pass layer, story folder path, scenario name, and ADR content (if loaded) |
+| `green-*` (except `green-acceptance`) | `Agent tool` (subagent_type: `green-agent`) — pass layer, story folder path, scenario name, and ADR content (if loaded) |
+| `green-acceptance` | **Inline** — no subagent. Main agent ensures the shared test DB is up (tech binding → "Test Database"), reads `green-agent.md`, loads acceptance template, enables the test, runs it. Full visibility for user. |
+| `/refactor` | `Agent tool` (subagent_type: `refactor-agent`) |
+| `/test-review` | `Agent tool` (subagent_type: `test-review-agent`) |
+| `/test-coverage` | `Agent tool` (subagent_type: `coverage-agent`) |
+
+Derive the layer from the checkbox (e.g., `red-adapter db` → layer `db`, `green-usecase` → layer `usecase`). Both red-agent and green-agent receive: layer, story folder path, scenario name, and ADR content (if loaded in step 6). The agent resolves test files and templates from its own workflow.
+
+**CHAINING: After each sub-step completes (Agent tool return), echo a 1-2 line status summary (agent name, outcome, pass/fail counts) to the user, then immediately dispatch the next sub-step. Do NOT wait for user input between sub-steps — the echo is informational only.**
+
+**AGENT LOG: Before the first agent dispatch, clear the log: `> infrastructure/agent-progress.log`. After the final commit, include the log contents in the stop-and-report summary.**
+
+**LOG REMINDER: Every time you dispatch a sub-agent (Agent tool call), output this line immediately before the call:**
+```
+> Dispatching {agent-name}. Live progress: tail -f infrastructure/agent-progress.log
+```
+**This reminds the user where to watch. The line appears in conversation output before the agent starts, so the user can open a terminal and tail the log while the agent works.**
+
+## Updating stories.md
+
+After updating `progress.md` for a **story** (not tasks), update the story's row in `ProductSpecification/stories.md` to reflect current phase status. The file has columns: `Spec | Backend | Integration | Frontend | Security | Load | Infra | Status`.
+
+**Phase column values** — derive from `progress.md` sections:
+- `✅` — all checkboxes in that section are `[x]` or `[S]`
+- `🔧` — section has at least one `[~]` or `[ ]` checkbox (work in progress or next up within the current active lifecycle phase)
+- `—` — section exists but no work started yet (all `[ ]`)
+- `n/a` — phase not applicable (test spec file says "No tests" or story has no scenarios for that phase)
+- `·` — no story folder or no progress file exists
+
+**Tests and % columns** — recount after every progress.md update:
+- **Total** = number of `### ` scenario headings in progress.md (not `## ` section headers)
+- **Done** = scenarios where ALL checkboxes are `[x]` or `[S]` (no `[ ]` or `[~]` remaining)
+- **%** = `round(done / total * 100)`
+- Format: `done/total` in Tests column, `N%` in % column
+- Do NOT add a Total row — it causes merge conflicts
+
+**Story completion** — when all scenarios reach 100% (Tests column = `total/total`, % = `100%`), move the story row from the **In Progress** table to the **Done** table in `ProductSpecification/stories.md`. Keep all column values intact.
+
+**When to update**: after every progress.md commit for a story. Include `ProductSpecification/stories.md` in the same commit.
+
+**Lifecycle ordering**: Spec → Backend → Integration → Frontend → Security → Load → Infra. A phase becomes `🔧` when it is the current active phase (has `[~]` items) OR when it still has `[ ]` items and all prior phases are `✅`.

--- a/.claude/templates/workflow/design-preview-formats.md
+++ b/.claude/templates/workflow/design-preview-formats.md
@@ -1,0 +1,37 @@
+# Design-Preview Formats
+
+Reference formats for the `/design-preview` skill: option-presentation depth, the two `AskUserQuestion` prompts (option choice + ADR decision), and the completion-outcome table. The skill keeps the decision flow inline and points here for these format details.
+
+## Option Presentation Depth
+
+Show each option as a labelled block: title, summary, pros, cons. Include the recommendation rationale below the recommended option.
+
+- **Simple scenarios**: each option in 3-5 lines.
+- **Complex scenarios**: each option with method signatures/pseudocode, domain model changes, pipeline/sequence diagrams, port changes.
+
+## AskUserQuestion — Option Choice
+
+- First answer = the recommended option, label suffixed with "(Recommended)"
+- Other answers = alternative options (one per non-recommended option, up to 3 alternatives)
+- Last answer = "Reject all — escalate to `/architecture`"
+
+Option labels must fit in a chip (12 chars). Keep answer descriptions to one short line.
+
+If user rejects all → invoke `/architecture` and STOP. Do not proceed to the ADR question.
+
+## AskUserQuestion — ADR Decision
+
+After an option is chosen, ask separately whether to capture the decision as an ADR:
+
+- "Write ADR" — recommended when the user picked a non-recommended option, when the trade-offs are non-obvious, or when downstream scenarios will likely revisit the choice
+- "Skip ADR" — recommended for trivial scenarios (single-option flow) or mechanical choices with no real trade-off
+
+Pick which option to mark "(Recommended)" based on the choice the user just made in the option-choice step.
+
+## Completion Outcome Table
+
+| Outcome | Action |
+|---------|--------|
+| Option chosen, no ADR | Mark `design` step as `[x]`. No files created. |
+| Option chosen, write ADR | Mark `design` step as `[x]`, then write an ADR using `.claude/templates/spec/adr-format.md` to the story's `decisions/` subfolder. Pre-populate the ADR's "Rejected" table with the un-chosen options from the present-options step. Commit includes the ADR file. |
+| Rejected all → `/architecture` | Do NOT mark `design`. `/architecture` runs and decides the ADR. Mark `design` only after the ADR lands. |

--- a/.claude/templates/workflow/red-phase-layer-notes.md
+++ b/.claude/templates/workflow/red-phase-layer-notes.md
@@ -1,0 +1,11 @@
+# Red Phase — Layer Notes (tech-agnostic)
+
+Tech-agnostic RED-phase procedure detail loaded on demand by `red-agent`.
+
+## Context Files
+
+Before writing tests, read:
+1. Read `ProductSpecification/stories.md` to resolve story numbers to names and folder paths.
+2. `ProductSpecification/stories/{story}/` - story details
+3. Layer template (see "Template by Layer" table in `red-agent.md`)
+4. Existing tests in the target module

--- a/.claude/templates/workflow/test-runner-output-format.md
+++ b/.claude/templates/workflow/test-runner-output-format.md
@@ -1,0 +1,26 @@
+# Test Runner Output Format
+
+The `test-runner` agent reports results using this structure:
+
+```
+## Test Results
+
+**Module:** {module}
+**Test class:** {testClass or "all"}
+
+**Result:** PASSED | FAILED | SKIPPED
+
+**Output:**
+```
+{test output}
+```
+
+**Summary:**
+- Tests run: N
+- Passed: N
+- Failed: N
+- Skipped: N
+
+**Failed tests:** (if any)
+- TestClass > testMethod() - failure reason
+```


### PR DESCRIPTION
Resolves the structural smells found by a full `/prompt-refactor` scan of `.claude/` (scope: **A1 size + A2 fenced blocks**; B6 command-hardcoding and B4 cross-layer dedup deliberately left out of scope).

## What changed

**A1 — files brought within the size limits (agent ≤100, skill ≤70):**

| File | Before | After |
|------|--------|-------|
| `continue` (skill) | 137 | 52 |
| `red-agent` | 130 | 78 |
| `checkstyle-review` | 96 | 38 |
| `screenshot` | 92 | 47 |
| `demo` | 89 | 44 |
| `design-preview` | 80 | 61 |
| `doc` | 78 | 36 |
| `task` | 75 | 69 |

**A2 — fenced code blocks moved out of agents/skills:** `test-runner` output scaffold and the `prompt-update` classification example.

## How

Reference material relocated **verbatim** into 9 new templates (nothing dropped — relocation only). Tech-specific content (Maven/checkstyle, Playwright config, framework annotations) was placed under `.claude/tech/{concern}/templates/` rather than universal `.claude/templates/`, so the extraction does **not** introduce a new B6 (tech-leakage) violation in another layer. All references verified to resolve to existing files.

## Why it matters

Agent/skill bodies load into context on activation; oversized bodies tax every invocation. Moving the heavy reference material into on-demand templates keeps the always-loaded surface thin while preserving full detail behind a `Read`.

## Out of scope (follow-up)
- **B6** — hardcoded commands/ports in `run-backend`/`stop-backend`/`cleanup-chrome`/`test-adapter`/`test-usecase` + literal `java-spring` vs `{backend}` token in agents.
- **B4** — cross-layer duplication with `tdd-rules.md`/`workflow.md`/`coding-rules.md`.

Docs-only change; Java static analysis (checkstyle/PMD/SpotBugs) is not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)