### PR TITLE
docs(rules): prefer IDE/MCP introspection over Read/Grep for structured facts

### DIFF
--- a/.claude/rules/mcp-introspection.md
+++ b/.claude/rules/mcp-introspection.md
@@ -1,0 +1,23 @@
+# Structured Code Introspection (IDE / MCP)
+
+When you need **structured facts** about the codebase — project/module structure, domain
+entities and their fields, REST endpoints, Spring beans and the DI graph, security
+configuration, configuration properties, DB migrations — prefer the IDE introspection
+tools exposed over MCP instead of reconstructing the same facts from raw text with
+`Read`/`Grep`. Introspection returns typed, complete results; text search returns
+fragments you must reassemble and can miss generated or framework-derived structure.
+
+This project exposes such tools via the **amplicode** (and JetBrains **idea**) MCP
+servers. They are *deferred* tools — discover and load their schemas with
+`ToolSearch` (e.g. `ToolSearch "amplicode entities"`, `ToolSearch "amplicode endpoints"`),
+then call. The concrete situation→tool mapping lives in
+`.claude/tech/{backend}/mcp-introspection.md` — consult it the first time you reach for
+project structure in a session.
+
+Keep using `Read`/`Grep` for: non-Java files, free-text or symbol search, reading one
+already-known file, exact test contents, and anything the introspection tools do not
+model.
+
+**Fallback (mandatory):** the IDE MCP is available only while the IDE is open with the
+plugin active. In headless/cron runs, or if a `ToolSearch`/MCP call fails, fall back to
+`Read`/`Grep` — never block on the MCP being present.

--- a/.claude/rules/mcp-introspection.md
+++ b/.claude/rules/mcp-introspection.md
@@ -2,10 +2,11 @@
 
 When you need **structured facts** about the codebase — project/module structure, domain
 entities and their fields, REST endpoints, Spring beans and the DI graph, security
-configuration, configuration properties, DB migrations — prefer the IDE introspection
-tools exposed over MCP instead of reconstructing the same facts from raw text with
-`Read`/`Grep`. Introspection returns typed, complete results; text search returns
-fragments you must reassemble and can miss generated or framework-derived structure.
+configuration, configuration properties, DB migrations, the **live database** schema and
+data, a symbol's type/usages, or a method's call flow — prefer the IDE introspection tools
+exposed over MCP instead of reconstructing the same facts from raw text with `Read`/`Grep`.
+Introspection returns typed, complete results; text search returns fragments you must
+reassemble and can miss generated or framework-derived structure.
 
 This project exposes such tools via the **amplicode** (and JetBrains **idea**) MCP
 servers. They are *deferred* tools — discover and load their schemas with
@@ -14,7 +15,11 @@ then call. The concrete situation→tool mapping lives in
 `.claude/tech/{backend}/mcp-introspection.md` — consult it the first time you reach for
 project structure in a session.
 
-Keep using `Read`/`Grep` for: non-Java files, free-text or symbol search, reading one
+The same IDE MCP also exposes two adjacent capabilities worth preferring: **validating a
+file** (compiler/inspection errors+warnings without a full build) and **safe project-wide
+symbol rename** (over a text-only `Edit replace_all`). Both are in the binding above.
+
+Keep using `Read`/`Grep` for: non-Java files, plain text/regex search, reading one
 already-known file, exact test contents, and anything the introspection tools do not
 model.
 

--- a/.claude/tech/java-spring/mcp-introspection.md
+++ b/.claude/tech/java-spring/mcp-introspection.md
@@ -1,9 +1,19 @@
 # MCP Code Introspection — Tool Mapping (Java/Spring: amplicode + idea)
 
-Prefer these amplicode MCP tools over ad-hoc `Read`/`Grep` for structured facts about the
-project. Load schemas via `ToolSearch "select:<name>,<name>"` (or a keyword search), then
-call. See `.claude/rules/mcp-introspection.md` for the universal principle and the
-fallback policy.
+Two MCP servers expose structured introspection — prefer them over reconstructing facts
+from raw text with `Read`/`Grep`. Load schemas via `ToolSearch` (keyword search or
+`select:<name>`), then call. See `.claude/rules/mcp-introspection.md` for the universal
+principle and the fallback policy.
+
+**Division of labour:**
+- **amplicode** — the Spring/JPA *semantic* model: entities, repositories, DTOs, mappers,
+  endpoints, beans & the DI graph, security roles, profiles, properties, migrations. Ask
+  it *"what does the framework see"*.
+- **idea** (JetBrains) — generic IDE intelligence: symbol resolution & docs, code problems
+  (inspections), call-flow diagrams, the **live database** (schema + data), safe rename
+  refactoring, module/dependency graph. Ask it *"what do the compiler, IDE, and DB see"*.
+
+## amplicode — Spring/JPA semantics
 
 | When you need…                | Prefer (`mcp__amplicode__…`)                                          | Instead of                       |
 |-------------------------------|----------------------------------------------------------------------|----------------------------------|
@@ -15,15 +25,41 @@ fallback policy.
 | security config / roles       | `list_security_configurations`, `list_spring_security_roles`         | grep `SecurityFilterChain`       |
 | profiles / datasources        | `list_spring_profiles`, `list_project_datasources`                   | reading config manually          |
 | configuration properties      | `list_application_properties_files`, `get_properties_values`         | reading `application.yml` by hand |
-| DB migrations                 | `list_db_migration_files`                                            | `ls` the migration folder        |
+| DB migration files            | `list_db_migration_files`                                            | `ls` the migration folder        |
 | read a compiled/class file    | `read_class_file`, `analyze_files`                                   | —                                |
+
+## idea — IDE intelligence
+
+| When you need…                              | Prefer (`mcp__idea__…`)                                     | Instead of                          |
+|---------------------------------------------|-------------------------------------------------------------|-------------------------------------|
+| find a class/method/field by name           | `search_symbol`                                             | grep `class X` / `X(`               |
+| a symbol's type / signature / docs / declaration | `get_symbol_info` (file + 1-based line/column)         | reading the file to infer it        |
+| does a file compile / its errors + warnings | `get_file_problems` (`errorsOnly` toggles warnings)         | a full `./mvnw` build to surface issues |
+| a method's call flow                        | `generate_sequence_diagram` (returns Mermaid)               | manually tracing calls              |
+| modules / dependencies / VCS roots          | `get_project_modules`, `get_project_dependencies`, `get_repositories` | grep build files           |
+| **live DB** schema (columns / keys / indexes) | `list_database_connections` → `list_schema_objects`, `get_database_object_description` | reading migration files |
+| **live DB** rows / ad-hoc query             | `preview_table_data`, `execute_sql_query`                   | guessing the data state             |
 
 ## Notes
 
-- **Runtime debugging** (breakpoints, stepping, `evaluate_expression`, stack traces) is a
-  separate workflow — use the `ij-debugger` skill, not this table.
-- **Test execution:** `run_tests`/`list_test_files` exist, but this project standardizes
-  test runs through its test skills / the Conventions table in `ProductSpecification/technology.md`.
-  Prefer those for consistency; reach for the MCP runner only when a skill doesn't fit.
-- **Availability:** every tool requires the IDE open with the amplicode plugin active.
-  If unavailable or a call fails, fall back to `Read`/`Grep` (see the rules file).
+- **Live DB vs migrations:** amplicode lists migration *files* (static intent); idea queries
+  the *running* database (actual schema + data) through its DB connections. Use idea to
+  confirm what the DB really contains. DB tools require a configured connection — start from
+  `list_database_connections`.
+- **Validate without a full build:** prefer `get_file_problems` (IDE inspections) to check a
+  single file for errors/warnings instead of running the whole `./mvnw verify`. The real
+  build/CI commands (see Conventions table in `ProductSpecification/technology.md`) remain the
+  authoritative gate before commit.
+- **Safe rename:** to rename a programmatic symbol (class/method/field), prefer
+  `mcp__idea__rename_refactoring` — it updates ALL references project-wide — over `Edit` with
+  `replace_all`, which is text-only and silently misses references or over-matches. Fall back
+  to `Edit` only when the IDE is unavailable.
+- **Plain text / regex search stays on `Grep`/`Glob`** (ripgrep-backed — fast, integrated with
+  the permission UI). Reach for idea's `search_symbol` / `get_symbol_info` when you need
+  *symbol-level* semantics, not literal text.
+- **Formatting:** do NOT use `mcp__idea__reformat_file` — this project's canonical format is
+  Spotless + Palantir (`./mvnw spotless:apply`); IDE reformat may diverge.
+- **Runtime debugging** (breakpoints, stepping, evaluate, stacks) is exposed by both servers
+  (`mcp__idea__xdebug_*` and amplicode debug tools) — use the `ij-debugger` skill, not this table.
+- **Availability:** every tool needs the IDE open with the plugin active (DB tools also need a
+  live connection). If unavailable or a call fails, fall back to `Read`/`Grep`/build commands.

--- a/.claude/tech/java-spring/mcp-introspection.md
+++ b/.claude/tech/java-spring/mcp-introspection.md
@@ -1,0 +1,29 @@
+# MCP Code Introspection — Tool Mapping (Java/Spring: amplicode + idea)
+
+Prefer these amplicode MCP tools over ad-hoc `Read`/`Grep` for structured facts about the
+project. Load schemas via `ToolSearch "select:<name>,<name>"` (or a keyword search), then
+call. See `.claude/rules/mcp-introspection.md` for the universal principle and the
+fallback policy.
+
+| When you need…                | Prefer (`mcp__amplicode__…`)                                          | Instead of                       |
+|-------------------------------|----------------------------------------------------------------------|----------------------------------|
+| project overview / modules    | `get_project_summary`, `list_module_dependencies`                    | grep `pom.xml`, dir listing      |
+| domain entities & fields      | `list_all_domain_entities`, `get_entity_details`, `get_jdbc_entity_details` | grep `@Entity`             |
+| repositories / DTOs / mappers | `list_entity_repositories`, `list_entity_dtos`, `list_entity_mappers` | grep                             |
+| REST endpoints                | `list_project_endpoints`, `get_endpoint_info`                        | grep `@GetMapping`/`@RestController` |
+| Spring beans / DI graph       | `list_spring_beans`, `get_bean_injection_info`                       | grep `@Service`/`@Component`     |
+| security config / roles       | `list_security_configurations`, `list_spring_security_roles`         | grep `SecurityFilterChain`       |
+| profiles / datasources        | `list_spring_profiles`, `list_project_datasources`                   | reading config manually          |
+| configuration properties      | `list_application_properties_files`, `get_properties_values`         | reading `application.yml` by hand |
+| DB migrations                 | `list_db_migration_files`                                            | `ls` the migration folder        |
+| read a compiled/class file    | `read_class_file`, `analyze_files`                                   | —                                |
+
+## Notes
+
+- **Runtime debugging** (breakpoints, stepping, `evaluate_expression`, stack traces) is a
+  separate workflow — use the `ij-debugger` skill, not this table.
+- **Test execution:** `run_tests`/`list_test_files` exist, but this project standardizes
+  test runs through its test skills / the Conventions table in `ProductSpecification/technology.md`.
+  Prefer those for consistency; reach for the MCP runner only when a skill doesn't fit.
+- **Availability:** every tool requires the IDE open with the amplicode plugin active.
+  If unavailable or a call fails, fall back to `Read`/`Grep` (see the rules file).


### PR DESCRIPTION
Adds an always-loaded rule that biases tool choice toward the **amplicode** and JetBrains **idea** MCP introspection tools when the model needs structured facts about the project — instead of reconstructing them from raw text with `Read`/`Grep`.

## Motivation

MCP tools are *deferred* in this harness (must be `ToolSearch`-loaded before use), while `Read`/`Grep` are always available in one call — so the model defaults to text search even when structured introspection would give richer, complete results. An always-loaded routing rule counters that (same pattern as the existing global `context7.md`).

## Layering (per the project's own docs conventions)

- **`.claude/rules/mcp-introspection.md`** (always loaded) — the tech-agnostic *principle* + discovery hint + mandatory `Read`/`Grep` fallback.
- **`.claude/tech/java-spring/mcp-introspection.md`** (on-demand) — the concrete situation→tool mapping, keeping tool-specific names out of the universal layer.

## Tool coverage

- **amplicode** — Spring/JPA semantic model: entities, repositories, DTOs, endpoints, beans & DI graph, security roles, profiles, properties, migration files.
- **idea** — generic IDE intelligence: `search_symbol`/`get_symbol_info` (symbols & types), `get_file_problems` (validate a file via inspections without a full build), `generate_sequence_diagram` (call flow), the **live database** (schema + data, vs amplicode's static migration files), and `rename_refactoring` (safe project-wide rename, vs text-only `Edit replace_all`).

## Explicit boundaries (avoid false bias)
- Plain text/regex search stays on `Grep`/`Glob`.
- Formatting stays on Spotless/Palantir (`reformat_file` not used).
- Runtime debugging stays with the `ij-debugger` skill.
- Hard fallback to `Read`/`Grep` when the IDE/MCP is unavailable (headless/cron runs).

Subagents inherit the rule (it lives in the always-loaded `.claude/rules/` layer). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)