### PR TITLE
Task 210: Translate frontend UI text from Russian to English

### DIFF
--- a/ProductSpecification/stories/03-home-page/mockups/desktop/01-welcome.html
+++ b/ProductSpecification/stories/03-home-page/mockups/desktop/01-welcome.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=1400">
-    <title>RPM — Добро пожаловать</title>
+    <title>RPM — Welcome</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -84,14 +84,14 @@
 <body>
     <div class="welcome">
         <div class="welcome-logo">RPM</div>
-        <div class="welcome-tagline">Удалённый мониторинг пациентов</div>
+        <div class="welcome-tagline">Remote Patient Monitoring</div>
         <p class="welcome-text">
-            Платформа непрерывного наблюдения за состоянием пациентов
-            и автоматических оповещений об отклонениях показателей.
+            A platform for continuous monitoring of patient health
+            with automatic alerts on abnormal readings.
         </p>
         <a href="#" class="btn-primary">
             <i data-lucide="log-in"></i>
-            Войти
+            Sign in
         </a>
     </div>
 

--- a/ProductSpecification/stories/03-home-page/mockups/desktop/02-dashboard.html
+++ b/ProductSpecification/stories/03-home-page/mockups/desktop/02-dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=1400">
-    <title>RPM — Главная</title>
+    <title>RPM — Home</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -116,23 +116,23 @@
     <header class="topbar">
         <div class="topbar-logo">RPM</div>
         <div class="user-menu">
-            <div class="avatar">ИП</div>
-            <span class="user-name">Иван Петров</span>
+            <div class="avatar">JD</div>
+            <span class="user-name">John Doe</span>
             <i data-lucide="chevron-down"></i>
         </div>
     </header>
 
     <div class="layout">
         <aside class="sidebar">
-            <div class="sidebar-placeholder">Разделы появятся<br>по мере подключения модулей</div>
+            <div class="sidebar-placeholder">Sections will appear<br>as modules are connected</div>
         </aside>
 
         <main class="content">
-            <h1 class="page-title">Главная</h1>
+            <h1 class="page-title">Home</h1>
             <div class="empty-state">
                 <i data-lucide="layout-dashboard" class="empty-icon"></i>
-                <div class="empty-title">Панель управления</div>
-                <p class="empty-desc">Здесь появятся данные по пациентам, заказам и оповещениям по мере подключения модулей.</p>
+                <div class="empty-title">Dashboard</div>
+                <p class="empty-desc">Patient, order, and alert data will appear here as modules are connected.</p>
             </div>
         </main>
     </div>

--- a/ProductSpecification/stories/03-home-page/mockups/desktop/03-dashboard-user-menu.html
+++ b/ProductSpecification/stories/03-home-page/mockups/desktop/03-dashboard-user-menu.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=1400">
-    <title>RPM — Главная (меню пользователя)</title>
+    <title>RPM — Home (user menu)</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -141,19 +141,19 @@
         <div class="topbar-logo">RPM</div>
         <div class="user-menu-wrap">
             <div class="user-menu">
-                <div class="avatar">ИП</div>
-                <span class="user-name">Иван Петров</span>
+                <div class="avatar">JD</div>
+                <span class="user-name">John Doe</span>
                 <i data-lucide="chevron-up"></i>
             </div>
             <div class="dropdown">
                 <div class="dropdown-header">
-                    <div class="dh-name">Иван Петров</div>
-                    <div class="dh-email">i.petrov@rpm.local</div>
+                    <div class="dh-name">John Doe</div>
+                    <div class="dh-email">j.doe@rpm.local</div>
                 </div>
                 <div class="dropdown-divider"></div>
                 <div class="dropdown-item">
                     <i data-lucide="log-out"></i>
-                    Выйти
+                    Log out
                 </div>
             </div>
         </div>
@@ -161,15 +161,15 @@
 
     <div class="layout">
         <aside class="sidebar">
-            <div class="sidebar-placeholder">Разделы появятся<br>по мере подключения модулей</div>
+            <div class="sidebar-placeholder">Sections will appear<br>as modules are connected</div>
         </aside>
 
         <main class="content">
-            <h1 class="page-title">Главная</h1>
+            <h1 class="page-title">Home</h1>
             <div class="empty-state">
                 <i data-lucide="layout-dashboard" class="empty-icon"></i>
-                <div class="empty-title">Панель управления</div>
-                <p class="empty-desc">Здесь появятся данные по пациентам, заказам и оповещениям по мере подключения модулей.</p>
+                <div class="empty-title">Dashboard</div>
+                <p class="empty-desc">Patient, order, and alert data will appear here as modules are connected.</p>
             </div>
         </main>
     </div>

--- a/ProductSpecification/stories/03-home-page/mockups/desktop/04-loading.html
+++ b/ProductSpecification/stories/03-home-page/mockups/desktop/04-loading.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=1400">
-    <title>RPM — Загрузка</title>
+    <title>RPM — Loading</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -42,7 +42,7 @@
 </head>
 <body>
     <i data-lucide="loader-2" class="spinner"></i>
-    <div class="loading-text">Загрузка…</div>
+    <div class="loading-text">Loading…</div>
 
     <script>lucide.createIcons();</script>
 </body>

--- a/ProductSpecification/stories/03-home-page/mockups/mobile/01-welcome.html
+++ b/ProductSpecification/stories/03-home-page/mockups/mobile/01-welcome.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=375">
-    <title>RPM — Добро пожаловать</title>
+    <title>RPM — Welcome</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -77,14 +77,14 @@
 <body>
     <div class="welcome">
         <div class="welcome-logo">RPM</div>
-        <div class="welcome-tagline">Удалённый мониторинг пациентов</div>
+        <div class="welcome-tagline">Remote Patient Monitoring</div>
         <p class="welcome-text">
-            Платформа непрерывного наблюдения за состоянием пациентов
-            и автоматических оповещений об отклонениях показателей.
+            A platform for continuous monitoring of patient health
+            with automatic alerts on abnormal readings.
         </p>
         <a href="#" class="btn-primary">
             <i data-lucide="log-in"></i>
-            Войти
+            Sign in
         </a>
     </div>
 

--- a/ProductSpecification/stories/03-home-page/mockups/mobile/02-dashboard.html
+++ b/ProductSpecification/stories/03-home-page/mockups/mobile/02-dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=375">
-    <title>RPM — Главная</title>
+    <title>RPM — Home</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -77,15 +77,15 @@
 <body>
     <header class="topbar">
         <div class="topbar-logo">RPM</div>
-        <div class="avatar">ИП</div>
+        <div class="avatar">JD</div>
     </header>
 
     <main class="content">
-        <h1 class="page-title">Главная</h1>
+        <h1 class="page-title">Home</h1>
         <div class="empty-state">
             <i data-lucide="layout-dashboard" class="empty-icon"></i>
-            <div class="empty-title">Панель управления</div>
-            <p class="empty-desc">Здесь появятся данные по пациентам, заказам и оповещениям по мере подключения модулей.</p>
+            <div class="empty-title">Dashboard</div>
+            <p class="empty-desc">Patient, order, and alert data will appear here as modules are connected.</p>
         </div>
     </main>
 

--- a/ProductSpecification/stories/03-home-page/mockups/mobile/03-dashboard-user-menu.html
+++ b/ProductSpecification/stories/03-home-page/mockups/mobile/03-dashboard-user-menu.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=375">
-    <title>RPM — Главная (меню пользователя)</title>
+    <title>RPM — Home (user menu)</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -109,26 +109,26 @@
 <body>
     <header class="topbar">
         <div class="topbar-logo">RPM</div>
-        <div class="avatar">ИП</div>
+        <div class="avatar">JD</div>
         <div class="dropdown">
             <div class="dropdown-header">
-                <div class="dh-name">Иван Петров</div>
-                <div class="dh-email">i.petrov@rpm.local</div>
+                <div class="dh-name">John Doe</div>
+                <div class="dh-email">j.doe@rpm.local</div>
             </div>
             <div class="dropdown-divider"></div>
             <div class="dropdown-item">
                 <i data-lucide="log-out"></i>
-                Выйти
+                Log out
             </div>
         </div>
     </header>
 
     <main class="content">
-        <h1 class="page-title">Главная</h1>
+        <h1 class="page-title">Home</h1>
         <div class="empty-state">
             <i data-lucide="layout-dashboard" class="empty-icon"></i>
-            <div class="empty-title">Панель управления</div>
-            <p class="empty-desc">Здесь появятся данные по пациентам, заказам и оповещениям по мере подключения модулей.</p>
+            <div class="empty-title">Dashboard</div>
+            <p class="empty-desc">Patient, order, and alert data will appear here as modules are connected.</p>
         </div>
     </main>
 

--- a/ProductSpecification/stories/03-home-page/mockups/mobile/04-loading.html
+++ b/ProductSpecification/stories/03-home-page/mockups/mobile/04-loading.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=375">
-    <title>RPM — Загрузка</title>
+    <title>RPM — Loading</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -42,7 +42,7 @@
 </head>
 <body>
     <i data-lucide="loader-2" class="spinner"></i>
-    <div class="loading-text">Загрузка…</div>
+    <div class="loading-text">Loading…</div>
 
     <script>lucide.createIcons();</script>
 </body>

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
@@ -12,8 +12,8 @@ Type: bug
 - [x] red-acceptance-frontend (flip Playwright E2E + Statements expectations to English: home-page.statements, user-menu.statements, welcome-page, welcome-to-login, dashboard-page, user-menu, logout-to-welcome, login-to-dashboard; `test.fail` on the 5 that assert hardcoded UI text — login-to-dashboard stays green, fixture-only)
 - [x] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; `lang="en"` already set in index.html; removed Vitest `it.fails` in home.smoke)
 - [x] green-playwright (removed 5 `test.fail` markers; `rg "\p{Cyrillic}" frontend/src frontend/acceptance` clean; lint clean; full Playwright chromium suite green — 25 passed)
-- [~] translate-mockups (translate 8 Story 03 home-page mockup HTML files to English; `rg "\p{Cyrillic}" ProductSpecification/stories/03-home-page/mockups` clean) — docs edit, no TDD cycle
-- [ ] demo
+- [x] translate-mockups (translated 8 Story 03 home-page mockup HTML files to English; `rg "\p{Cyrillic}" ProductSpecification/stories/03-home-page/mockups` clean; no PNG screenshots to regenerate) — docs edit, no TDD cycle
+- [~] demo
 
 > Scoped per `workflow.md` (scoped steps): text-only change, no `.logic.ts`/API/align-design work, so the logic/api/design steps of the standard frontend sequence are omitted.
 > Scope expanded mid-task (after `red-frontend`): `rg "\p{Cyrillic}"` at fix time surfaced Russian beyond the spec's original list — the Playwright acceptance suite (`frontend/acceptance/tests/frontend/home/*` + statements), which would break `green-playwright` once components are English, and the Story 03 mockups. User opted to translate the mockups within Task 210 (see spec.md "Key Files").

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
@@ -11,8 +11,8 @@ Type: bug
 - [x] red-frontend (flip existing Vitest expectations to English: home.smoke, dashboard-user.logic, auth.store, current-user.api, fetch.api)
 - [x] red-acceptance-frontend (flip Playwright E2E + Statements expectations to English: home-page.statements, user-menu.statements, welcome-page, welcome-to-login, dashboard-page, user-menu, logout-to-welcome, login-to-dashboard; `test.fail` on the 5 that assert hardcoded UI text — login-to-dashboard stays green, fixture-only)
 - [x] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; `lang="en"` already set in index.html; removed Vitest `it.fails` in home.smoke)
-- [~] green-playwright (run FE+BE; remove `test.fail` markers; `rg "\p{Cyrillic}" frontend/src frontend/acceptance` clean; `npm run lint` + Vitest + Playwright home suite green)
-- [ ] translate-mockups (translate 8 Story 03 home-page mockup HTML files to English; `rg "\p{Cyrillic}" ProductSpecification/stories/03-home-page/mockups` clean) — docs edit, no TDD cycle
+- [x] green-playwright (removed 5 `test.fail` markers; `rg "\p{Cyrillic}" frontend/src frontend/acceptance` clean; lint clean; full Playwright chromium suite green — 25 passed)
+- [~] translate-mockups (translate 8 Story 03 home-page mockup HTML files to English; `rg "\p{Cyrillic}" ProductSpecification/stories/03-home-page/mockups` clean) — docs edit, no TDD cycle
 - [ ] demo
 
 > Scoped per `workflow.md` (scoped steps): text-only change, no `.logic.ts`/API/align-design work, so the logic/api/design steps of the standard frontend sequence are omitted.

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
@@ -1,0 +1,16 @@
+# Task 210: Translate frontend UI text from Russian to English -- Progress
+
+Type: bug
+
+## Spec
+- [x] spec
+
+## Frontend
+
+### Fix: translate Russian UI strings to English (text only, no logic)
+- [ ] red-frontend (flip existing test expectations to English: home.smoke, dashboard-user.logic, auth.store, current-user.api, fetch.api)
+- [ ] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; set `lang="en"`)
+- [ ] green-playwright (run FE; `rg "\p{Cyrillic}" frontend/src` clean; `npm run lint` + frontend tests green)
+- [ ] demo
+
+> Scoped per `workflow.md` (scoped steps): text-only change, no `.logic.ts`/API/align-design work, so the logic/api/design steps of the standard frontend sequence are omitted.

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
@@ -8,8 +8,8 @@ Type: bug
 ## Frontend
 
 ### Fix: translate Russian UI strings to English (text only, no logic)
-- [ ] red-frontend (flip existing test expectations to English: home.smoke, dashboard-user.logic, auth.store, current-user.api, fetch.api)
-- [ ] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; set `lang="en"`)
+- [x] red-frontend (flip existing test expectations to English: home.smoke, dashboard-user.logic, auth.store, current-user.api, fetch.api)
+- [~] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; set `lang="en"`)
 - [ ] green-playwright (run FE; `rg "\p{Cyrillic}" frontend/src` clean; `npm run lint` + frontend tests green)
 - [ ] demo
 

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
@@ -10,8 +10,8 @@ Type: bug
 ### Fix: translate Russian UI strings to English (text only, no logic)
 - [x] red-frontend (flip existing Vitest expectations to English: home.smoke, dashboard-user.logic, auth.store, current-user.api, fetch.api)
 - [x] red-acceptance-frontend (flip Playwright E2E + Statements expectations to English: home-page.statements, user-menu.statements, welcome-page, welcome-to-login, dashboard-page, user-menu, logout-to-welcome, login-to-dashboard; `test.fail` on the 5 that assert hardcoded UI text — login-to-dashboard stays green, fixture-only)
-- [~] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; set `lang="en"`)
-- [ ] green-playwright (run FE+BE; remove `test.fail` markers; `rg "\p{Cyrillic}" frontend/src frontend/acceptance` clean; `npm run lint` + Vitest + Playwright home suite green)
+- [x] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; `lang="en"` already set in index.html; removed Vitest `it.fails` in home.smoke)
+- [~] green-playwright (run FE+BE; remove `test.fail` markers; `rg "\p{Cyrillic}" frontend/src frontend/acceptance` clean; `npm run lint` + Vitest + Playwright home suite green)
 - [ ] translate-mockups (translate 8 Story 03 home-page mockup HTML files to English; `rg "\p{Cyrillic}" ProductSpecification/stories/03-home-page/mockups` clean) — docs edit, no TDD cycle
 - [ ] demo
 

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
@@ -8,9 +8,12 @@ Type: bug
 ## Frontend
 
 ### Fix: translate Russian UI strings to English (text only, no logic)
-- [x] red-frontend (flip existing test expectations to English: home.smoke, dashboard-user.logic, auth.store, current-user.api, fetch.api)
-- [~] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; set `lang="en"`)
-- [ ] green-playwright (run FE; `rg "\p{Cyrillic}" frontend/src` clean; `npm run lint` + frontend tests green)
+- [x] red-frontend (flip existing Vitest expectations to English: home.smoke, dashboard-user.logic, auth.store, current-user.api, fetch.api)
+- [~] red-acceptance-frontend (flip Playwright E2E + Statements expectations to English: home-page.statements, user-menu.statements, welcome-page, welcome-to-login, dashboard-page, user-menu, logout-to-welcome, login-to-dashboard; `test.fail` markers where they go red against the still-Russian UI)
+- [ ] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; set `lang="en"`)
+- [ ] green-playwright (run FE+BE; remove `test.fail` markers; `rg "\p{Cyrillic}" frontend/src frontend/acceptance` clean; `npm run lint` + Vitest + Playwright home suite green)
+- [ ] translate-mockups (translate 8 Story 03 home-page mockup HTML files to English; `rg "\p{Cyrillic}" ProductSpecification/stories/03-home-page/mockups` clean) — docs edit, no TDD cycle
 - [ ] demo
 
 > Scoped per `workflow.md` (scoped steps): text-only change, no `.logic.ts`/API/align-design work, so the logic/api/design steps of the standard frontend sequence are omitted.
+> Scope expanded mid-task (after `red-frontend`): `rg "\p{Cyrillic}"` at fix time surfaced Russian beyond the spec's original list — the Playwright acceptance suite (`frontend/acceptance/tests/frontend/home/*` + statements), which would break `green-playwright` once components are English, and the Story 03 mockups. User opted to translate the mockups within Task 210 (see spec.md "Key Files").

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/progress.md
@@ -9,8 +9,8 @@ Type: bug
 
 ### Fix: translate Russian UI strings to English (text only, no logic)
 - [x] red-frontend (flip existing Vitest expectations to English: home.smoke, dashboard-user.logic, auth.store, current-user.api, fetch.api)
-- [~] red-acceptance-frontend (flip Playwright E2E + Statements expectations to English: home-page.statements, user-menu.statements, welcome-page, welcome-to-login, dashboard-page, user-menu, logout-to-welcome, login-to-dashboard; `test.fail` markers where they go red against the still-Russian UI)
-- [ ] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; set `lang="en"`)
+- [x] red-acceptance-frontend (flip Playwright E2E + Statements expectations to English: home-page.statements, user-menu.statements, welcome-page, welcome-to-login, dashboard-page, user-menu, logout-to-welcome, login-to-dashboard; `test.fail` on the 5 that assert hardcoded UI text — login-to-dashboard stays green, fixture-only)
+- [~] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; set `lang="en"`)
 - [ ] green-playwright (run FE+BE; remove `test.fail` markers; `rg "\p{Cyrillic}" frontend/src frontend/acceptance` clean; `npm run lint` + Vitest + Playwright home suite green)
 - [ ] translate-mockups (translate 8 Story 03 home-page mockup HTML files to English; `rg "\p{Cyrillic}" ProductSpecification/stories/03-home-page/mockups` clean) — docs edit, no TDD cycle
 - [ ] demo

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/spec.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/spec.md
@@ -1,0 +1,40 @@
+# Task 210: Translate frontend UI text from Russian to English
+
+Type: bug
+Issue: #210
+
+## Problem
+
+The product interface language is **English** (decided during Story 4 / User management). Already-merged `main` still renders **Russian** UI text in production Vue components, so the live app is in the wrong language.
+
+## Solution
+
+Replace every Russian user-visible string with its English equivalent and set `lang="en"` where applicable. Update the existing tests that assert the Russian strings to expect the English text. **Text only — no logic changes.**
+
+Verify with `rg "\p{Cyrillic}" frontend/src` that no Russian remains in production code; `npm run lint` and the frontend test suite must pass.
+
+## Key Files
+
+Production components:
+- `frontend/src/features/home/components/UserMenu.vue`
+- `frontend/src/features/home/components/DashboardShell.vue`
+- `frontend/src/features/home/components/WelcomeView.vue`
+- `frontend/src/app/components/AppLoading.vue`
+
+Tests asserting Russian strings (flip expected text to English):
+- `frontend/src/features/home/__tests__/home.smoke.test.ts`
+- `frontend/src/app/__tests__/dashboard-user.logic.test.ts`
+- `frontend/src/app/__tests__/current-user.api.test.ts`
+- `frontend/src/app/__tests__/fetch.api.test.ts`
+- `frontend/src/app/stores/__tests__/auth.store.test.ts`
+
+> Note: `LoginPage.vue` / `ActivationPage.vue` were checked and contain no Cyrillic — login/activation are already English. Scope is the home/dashboard chrome + `AppLoading` only. Re-confirm the full file list at fix time with `rg "\p{Cyrillic}" frontend/src`, as more Russian may have merged since.
+
+## Reproduction
+
+1. Run the frontend and sign in; observe Russian labels in the dashboard sidebar/topbar/user menu, the welcome screen, and the app-loading text.
+2. `rg "\p{Cyrillic}" frontend/src` returns matches in production components.
+
+## Notes
+
+This is a mechanical text change, not a logic defect: the TDD cycle is **flip the existing test expectations to English (red) → translate the components so they pass (green) → verify no Cyrillic remains (green-playwright) → demo**. No new tests are written; existing assertions are updated. If any genuinely new test is added, tag it with `#210` per the tech binding.

--- a/ProductSpecification/tasks/210-bug-translate-frontend-english/spec.md
+++ b/ProductSpecification/tasks/210-bug-translate-frontend-english/spec.md
@@ -21,19 +21,32 @@ Production components:
 - `frontend/src/features/home/components/WelcomeView.vue`
 - `frontend/src/app/components/AppLoading.vue`
 
-Tests asserting Russian strings (flip expected text to English):
+Vitest tests asserting Russian strings (flip expected text to English):
 - `frontend/src/features/home/__tests__/home.smoke.test.ts`
 - `frontend/src/app/__tests__/dashboard-user.logic.test.ts`
 - `frontend/src/app/__tests__/current-user.api.test.ts`
 - `frontend/src/app/__tests__/fetch.api.test.ts`
 - `frontend/src/app/stores/__tests__/auth.store.test.ts`
 
-> Note: `LoginPage.vue` / `ActivationPage.vue` were checked and contain no Cyrillic — login/activation are already English. Scope is the home/dashboard chrome + `AppLoading` only. Re-confirm the full file list at fix time with `rg "\p{Cyrillic}" frontend/src`, as more Russian may have merged since.
+Playwright acceptance tests + Statements asserting Russian strings (surfaced at fix time — flip to English):
+- `frontend/acceptance/tests/statements/frontend/home-page.statements.ts` (`WELCOME_TAGLINE`, `LOGIN_BUTTON_TEXT`, `PAGE_TITLE_TEXT`)
+- `frontend/acceptance/tests/statements/frontend/user-menu.statements.ts` (`LOGOUT_ACTION_TEXT`)
+- `frontend/acceptance/tests/frontend/home/welcome-page.spec.ts`
+- `frontend/acceptance/tests/frontend/home/welcome-to-login.spec.ts`
+- `frontend/acceptance/tests/frontend/home/dashboard-page.spec.ts`
+- `frontend/acceptance/tests/frontend/home/user-menu.spec.ts`
+- `frontend/acceptance/tests/frontend/home/logout-to-welcome.spec.ts`
+- `frontend/acceptance/tests/frontend/home/login-to-dashboard.spec.ts`
+
+Story 03 mockups (frozen artifacts of a completed story — user opted to translate within Task 210 so they stay consistent with the now-English UI; docs edit, no TDD cycle):
+- `ProductSpecification/stories/03-home-page/mockups/{desktop,mobile}/{01-welcome,02-dashboard,03-dashboard-user-menu,04-loading}.html` (8 files)
+
+> Note: `LoginPage.vue` / `ActivationPage.vue` were checked and contain no Cyrillic — login/activation are already English. Production-code scope is the home/dashboard chrome + `AppLoading`. Re-confirm the full file list at fix time with `rg "\p{Cyrillic}" frontend/src frontend/acceptance ProductSpecification/stories`, as more Russian may have merged since — this is how the acceptance suite and mockups above were found.
 
 ## Reproduction
 
 1. Run the frontend and sign in; observe Russian labels in the dashboard sidebar/topbar/user menu, the welcome screen, and the app-loading text.
-2. `rg "\p{Cyrillic}" frontend/src` returns matches in production components.
+2. `rg "\p{Cyrillic}" frontend/src frontend/acceptance ProductSpecification/stories/03-home-page` returns matches in production components, the Playwright acceptance suite, and the Story 03 mockups.
 
 ## Notes
 

--- a/ProductSpecification/tasks/done/210-bug-translate-frontend-english/progress.md
+++ b/ProductSpecification/tasks/done/210-bug-translate-frontend-english/progress.md
@@ -13,7 +13,7 @@ Type: bug
 - [x] green-frontend (translate WelcomeView, DashboardShell, UserMenu, AppLoading; `lang="en"` already set in index.html; removed Vitest `it.fails` in home.smoke)
 - [x] green-playwright (removed 5 `test.fail` markers; `rg "\p{Cyrillic}" frontend/src frontend/acceptance` clean; lint clean; full Playwright chromium suite green — 25 passed)
 - [x] translate-mockups (translated 8 Story 03 home-page mockup HTML files to English; `rg "\p{Cyrillic}" ProductSpecification/stories/03-home-page/mockups` clean; no PNG screenshots to regenerate) — docs edit, no TDD cycle
-- [~] demo
+- [x] demo (recorded dashboard-page.spec.ts run → test-results/demo-dashboard-page.webm, gitignored; 1 passed)
 
 > Scoped per `workflow.md` (scoped steps): text-only change, no `.logic.ts`/API/align-design work, so the logic/api/design steps of the standard frontend sequence are omitted.
 > Scope expanded mid-task (after `red-frontend`): `rg "\p{Cyrillic}"` at fix time surfaced Russian beyond the spec's original list — the Playwright acceptance suite (`frontend/acceptance/tests/frontend/home/*` + statements), which would break `green-playwright` once components are English, and the Story 03 mockups. User opted to translate the mockups within Task 210 (see spec.md "Key Files").

--- a/ProductSpecification/tasks/done/210-bug-translate-frontend-english/spec.md
+++ b/ProductSpecification/tasks/done/210-bug-translate-frontend-english/spec.md
@@ -48,6 +48,10 @@ Story 03 mockups (frozen artifacts of a completed story — user opted to transl
 1. Run the frontend and sign in; observe Russian labels in the dashboard sidebar/topbar/user menu, the welcome screen, and the app-loading text.
 2. `rg "\p{Cyrillic}" frontend/src frontend/acceptance ProductSpecification/stories/03-home-page` returns matches in production components, the Playwright acceptance suite, and the Story 03 mockups.
 
+## Full-Stack Journey Verdict
+
+**no-impact.** Text-only change to the home/dashboard chrome. The nightly full-stack journey (`account-lifecycle.fullstack.spec.ts`) exercises the register → activate → login lifecycle via `LoginPageStatements` / `ActivationPageStatements` (already English) and does not reuse `HomePageStatements` / `UserMenuStatements` nor assert any of the translated home/dashboard strings. No journey spec change required.
+
 ## Notes
 
 This is a mechanical text change, not a logic defect: the TDD cycle is **flip the existing test expectations to English (red) → translate the components so they pass (green) → verify no Cyrillic remains (green-playwright) → demo**. No new tests are written; existing assertions are updated. If any genuinely new test is added, tag it with `#210` per the tech binding.

--- a/frontend/acceptance/tests/frontend/home/dashboard-page.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/dashboard-page.spec.ts
@@ -22,8 +22,6 @@ test.describe('Dashboard Page', () => {
       'And the main area displays the page title "Home", ' +
       'And the main area displays placeholder dashboard content',
     async () => {
-      // RED — DashboardShell still renders the Russian page title "Главная" (Task 210); GREEN translates it to "Home"
-      test.fail();
       await currentUserBackend.givenAuthenticatedUser({ firstName: 'John', lastName: 'Doe' });
       await homePage.navigateToHomePage();
 

--- a/frontend/acceptance/tests/frontend/home/dashboard-page.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/dashboard-page.spec.ts
@@ -13,22 +13,24 @@ test.describe('Dashboard Page', () => {
 
   test(
     'UI Test Scenario 2.1: Authenticated home shows the dashboard shell with the current user - ' +
-      'Given an authenticated user with first name "Иван" and last name "Петров", ' +
+      'Given an authenticated user with first name "John" and last name "Doe", ' +
       'When the user navigates to the home page, ' +
       'Then the page displays the top bar with the "RPM" logo, ' +
-      'And the top bar displays the user\'s avatar with initials "ИП", ' +
-      'And the top bar displays the user\'s name "Иван Петров", ' +
+      'And the top bar displays the user\'s avatar with initials "JD", ' +
+      'And the top bar displays the user\'s name "John Doe", ' +
       'And the page displays the navigation sidebar, ' +
-      'And the main area displays the page title "Главная", ' +
+      'And the main area displays the page title "Home", ' +
       'And the main area displays placeholder dashboard content',
     async () => {
-      await currentUserBackend.givenAuthenticatedUser({ firstName: 'Иван', lastName: 'Петров' });
+      // RED — DashboardShell still renders the Russian page title "Главная" (Task 210); GREEN translates it to "Home"
+      test.fail();
+      await currentUserBackend.givenAuthenticatedUser({ firstName: 'John', lastName: 'Doe' });
       await homePage.navigateToHomePage();
 
       await homePage.assertDashboardShellIsVisible();
       await homePage.assertTopbarLogoIsVisible();
-      await homePage.assertUserAvatarShowsInitials('ИП');
-      await homePage.assertUserNameIsVisible('Иван Петров');
+      await homePage.assertUserAvatarShowsInitials('JD');
+      await homePage.assertUserNameIsVisible('John Doe');
       await homePage.assertSidebarIsVisible();
       await homePage.assertPageTitleIsVisible();
       await homePage.assertPlaceholderContentIsVisible();

--- a/frontend/acceptance/tests/frontend/home/login-to-dashboard.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/login-to-dashboard.spec.ts
@@ -26,7 +26,7 @@ test.describe('Login to Dashboard Navigation', () => {
       "And the dashboard shell is displayed with the user's name in the top bar",
     async () => {
       await authBackend.givenRegisteredUser('ipetrov', 'correct-pass');
-      await currentUserBackend.givenAuthenticatedUser({ firstName: 'Иван', lastName: 'Петров' });
+      await currentUserBackend.givenAuthenticatedUser({ firstName: 'John', lastName: 'Doe' });
       await loginPage.navigateToLoginPage();
 
       await loginPage.enterLoginText('ipetrov');
@@ -35,7 +35,7 @@ test.describe('Login to Dashboard Navigation', () => {
 
       await homePage.assertNavigatedToHomeUrl();
       await homePage.assertDashboardShellIsVisible();
-      await homePage.assertUserNameIsVisible('Иван Петров');
+      await homePage.assertUserNameIsVisible('John Doe');
     },
   );
 });

--- a/frontend/acceptance/tests/frontend/home/logout-to-welcome.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/logout-to-welcome.spec.ts
@@ -18,11 +18,13 @@ test.describe('Logout to Welcome Navigation', () => {
     'UI Test Scenario 4.3: Logging out from the user menu returns to the welcome page - ' +
       'Given an authenticated user is on the dashboard, ' +
       'And the user has opened the user menu, ' +
-      'When the user clicks "Выйти", ' +
+      'When the user clicks "Log out", ' +
       'Then the session is ended, ' +
-      'And the user is shown the welcome page with the "Войти" button',
+      'And the user is shown the welcome page with the "Sign in" button',
     async () => {
-      await currentUserBackend.givenAuthenticatedUserUntilLogout({ firstName: 'Иван', lastName: 'Петров' });
+      // RED — WelcomeView still renders the Russian "Войти" button after logout (Task 210); GREEN translates it to "Sign in"
+      test.fail();
+      await currentUserBackend.givenAuthenticatedUserUntilLogout({ firstName: 'John', lastName: 'Doe' });
       await homePage.navigateToHomePage();
       await homePage.clickUserAvatar();
 

--- a/frontend/acceptance/tests/frontend/home/logout-to-welcome.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/logout-to-welcome.spec.ts
@@ -22,8 +22,6 @@ test.describe('Logout to Welcome Navigation', () => {
       'Then the session is ended, ' +
       'And the user is shown the welcome page with the "Sign in" button',
     async () => {
-      // RED — WelcomeView still renders the Russian "Войти" button after logout (Task 210); GREEN translates it to "Sign in"
-      test.fail();
       await currentUserBackend.givenAuthenticatedUserUntilLogout({ firstName: 'John', lastName: 'Doe' });
       await homePage.navigateToHomePage();
       await homePage.clickUserAvatar();

--- a/frontend/acceptance/tests/frontend/home/user-menu.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/user-menu.spec.ts
@@ -23,8 +23,6 @@ test.describe('User Menu', () => {
       'And the menu displays the email "j.doe@rpm.local", ' +
       'And the menu displays an action with text "Log out"',
     async () => {
-      // RED — UserMenu still renders the Russian "Выйти" logout action (Task 210); GREEN translates it to "Log out"
-      test.fail();
       await currentUserBackend.givenAuthenticatedUser({
         firstName: 'John',
         lastName: 'Doe',

--- a/frontend/acceptance/tests/frontend/home/user-menu.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/user-menu.spec.ts
@@ -16,25 +16,27 @@ test.describe('User Menu', () => {
 
   test(
     "UI Test Scenario 3.1: Opening the user menu shows the user's name, email, and logout action - " +
-      'Given an authenticated user with name "Иван Петров" and email "i.petrov@rpm.local", ' +
+      'Given an authenticated user with name "John Doe" and email "j.doe@rpm.local", ' +
       'And the user is on the dashboard, ' +
       'When the user clicks the avatar in the top bar, ' +
-      'Then a menu opens displaying the name "Иван Петров", ' +
-      'And the menu displays the email "i.petrov@rpm.local", ' +
-      'And the menu displays an action with text "Выйти"',
+      'Then a menu opens displaying the name "John Doe", ' +
+      'And the menu displays the email "j.doe@rpm.local", ' +
+      'And the menu displays an action with text "Log out"',
     async () => {
+      // RED — UserMenu still renders the Russian "Выйти" logout action (Task 210); GREEN translates it to "Log out"
+      test.fail();
       await currentUserBackend.givenAuthenticatedUser({
-        firstName: 'Иван',
-        lastName: 'Петров',
-        email: 'i.petrov@rpm.local',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'j.doe@rpm.local',
       });
       await homePage.navigateToHomePage();
 
       await homePage.clickUserAvatar();
 
       await userMenu.assertMenuIsOpen();
-      await userMenu.assertMenuShowsName('Иван Петров');
-      await userMenu.assertMenuShowsEmail('i.petrov@rpm.local');
+      await userMenu.assertMenuShowsName('John Doe');
+      await userMenu.assertMenuShowsEmail('j.doe@rpm.local');
       await userMenu.assertMenuShowsLogoutAction();
     },
   );

--- a/frontend/acceptance/tests/frontend/home/welcome-page.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/welcome-page.spec.ts
@@ -16,10 +16,12 @@ test.describe('Welcome Page', () => {
       'Given the user is not authenticated, ' +
       'When the user navigates to the home page, ' +
       'Then the page displays the "RPM" logo, ' +
-      'And the page displays the tagline "Удалённый мониторинг пациентов", ' +
-      'And the page displays a button with text "Войти", ' +
+      'And the page displays the tagline "Remote Patient Monitoring", ' +
+      'And the page displays a button with text "Sign in", ' +
       'And the dashboard shell is not displayed',
     async () => {
+      // RED — WelcomeView still renders the Russian tagline/"Войти" button (Task 210); GREEN translates them
+      test.fail();
       await currentUserBackend.givenUnauthenticated();
       await homePage.navigateToHomePage();
 

--- a/frontend/acceptance/tests/frontend/home/welcome-page.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/welcome-page.spec.ts
@@ -20,8 +20,6 @@ test.describe('Welcome Page', () => {
       'And the page displays a button with text "Sign in", ' +
       'And the dashboard shell is not displayed',
     async () => {
-      // RED — WelcomeView still renders the Russian tagline/"Войти" button (Task 210); GREEN translates them
-      test.fail();
       await currentUserBackend.givenUnauthenticated();
       await homePage.navigateToHomePage();
 

--- a/frontend/acceptance/tests/frontend/home/welcome-to-login.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/welcome-to-login.spec.ts
@@ -21,8 +21,6 @@ test.describe('Welcome to Login Navigation', () => {
       'When the user clicks the "Sign in" button, ' +
       'Then the user is navigated to the login page',
     async () => {
-      // RED — WelcomeView still renders the Russian "Войти" button (Task 210); GREEN translates it to "Sign in"
-      test.fail();
       await currentUserBackend.givenUnauthenticated();
       await homePage.navigateToHomePage();
       await homePage.assertLoginButtonIsVisible();

--- a/frontend/acceptance/tests/frontend/home/welcome-to-login.spec.ts
+++ b/frontend/acceptance/tests/frontend/home/welcome-to-login.spec.ts
@@ -15,12 +15,14 @@ test.describe('Welcome to Login Navigation', () => {
   });
 
   test(
-    'UI Test Scenario 4.1: Clicking "Войти" on the welcome page opens the login page - ' +
+    'UI Test Scenario 4.1: Clicking "Sign in" on the welcome page opens the login page - ' +
       'Given the user is not authenticated, ' +
       'And the user is on the welcome page, ' +
-      'When the user clicks the "Войти" button, ' +
+      'When the user clicks the "Sign in" button, ' +
       'Then the user is navigated to the login page',
     async () => {
+      // RED — WelcomeView still renders the Russian "Войти" button (Task 210); GREEN translates it to "Sign in"
+      test.fail();
       await currentUserBackend.givenUnauthenticated();
       await homePage.navigateToHomePage();
       await homePage.assertLoginButtonIsVisible();

--- a/frontend/acceptance/tests/statements/frontend/home-page.statements.ts
+++ b/frontend/acceptance/tests/statements/frontend/home-page.statements.ts
@@ -15,9 +15,9 @@ const TEST_ID = {
 } as const;
 
 const BRAND_LOGO_TEXT = 'RPM';
-const WELCOME_TAGLINE = 'Удалённый мониторинг пациентов';
-const LOGIN_BUTTON_TEXT = 'Войти';
-const PAGE_TITLE_TEXT = 'Главная';
+const WELCOME_TAGLINE = 'Remote Patient Monitoring';
+const LOGIN_BUTTON_TEXT = 'Sign in';
+const PAGE_TITLE_TEXT = 'Home';
 
 export class HomePageStatements {
   constructor(
@@ -44,12 +44,12 @@ export class HomePageStatements {
 
   async assertTaglineIsVisible(): Promise<void> {
     await expect(this.welcomeTagline(), 'tagline is visible').toBeVisible();
-    await expect(this.welcomeTagline(), 'tagline shows the exact Russian text').toHaveText(WELCOME_TAGLINE);
+    await expect(this.welcomeTagline(), 'tagline shows the exact text').toHaveText(WELCOME_TAGLINE);
   }
 
   async assertLoginButtonIsVisible(): Promise<void> {
     await expect(this.welcomeLoginButton(), 'login button is visible').toBeVisible();
-    await expect(this.welcomeLoginButton(), 'login button text is exactly "Войти"').toHaveText(LOGIN_BUTTON_TEXT);
+    await expect(this.welcomeLoginButton(), 'login button text is exactly "Sign in"').toHaveText(LOGIN_BUTTON_TEXT);
   }
 
   async clickLoginButton(): Promise<void> {
@@ -89,7 +89,7 @@ export class HomePageStatements {
 
   async assertPageTitleIsVisible(): Promise<void> {
     await expect(this.pageTitle(), 'page title is visible').toBeVisible();
-    await expect(this.pageTitle(), 'page title shows "Главная"').toHaveText(PAGE_TITLE_TEXT);
+    await expect(this.pageTitle(), 'page title shows "Home"').toHaveText(PAGE_TITLE_TEXT);
   }
 
   async assertPlaceholderContentIsVisible(): Promise<void> {

--- a/frontend/acceptance/tests/statements/frontend/user-menu.statements.ts
+++ b/frontend/acceptance/tests/statements/frontend/user-menu.statements.ts
@@ -7,7 +7,7 @@ const TEST_ID = {
   userMenuLogout: 'user-menu-logout',
 } as const;
 
-const LOGOUT_ACTION_TEXT = 'Выйти';
+const LOGOUT_ACTION_TEXT = 'Log out';
 
 export class UserMenuStatements {
   constructor(private readonly page: Page) {}
@@ -28,7 +28,7 @@ export class UserMenuStatements {
 
   async assertMenuShowsLogoutAction(): Promise<void> {
     await expect(this.userMenuLogout(), 'logout action is visible').toBeVisible();
-    await expect(this.userMenuLogout(), 'logout action text is exactly "Выйти"').toHaveText(LOGOUT_ACTION_TEXT);
+    await expect(this.userMenuLogout(), 'logout action text is exactly "Log out"').toHaveText(LOGOUT_ACTION_TEXT);
   }
 
   async clickLogout(): Promise<void> {

--- a/frontend/src/app/__tests__/current-user.api.test.ts
+++ b/frontend/src/app/__tests__/current-user.api.test.ts
@@ -29,10 +29,10 @@ function stubMeAuthenticated(): void {
   stubMe(
     {
       userId: '11111111-1111-1111-1111-111111111111',
-      login: 'ipetrov',
-      email: 'i.petrov@rpm.local',
-      firstName: 'Иван',
-      lastName: 'Петров',
+      login: 'jdoe',
+      email: 'j.doe@rpm.local',
+      firstName: 'John',
+      lastName: 'Doe',
       status: 'ACTIVE',
       roles: [],
     },
@@ -58,10 +58,10 @@ describe('Current User API Client', () => {
     const expected: CurrentUserResult = {
       authenticated: true,
       user: {
-        login: 'ipetrov',
-        email: 'i.petrov@rpm.local',
-        firstName: 'Иван',
-        lastName: 'Петров',
+        login: 'jdoe',
+        email: 'j.doe@rpm.local',
+        firstName: 'John',
+        lastName: 'Doe',
       },
     };
     expect(result).toEqual(expected);

--- a/frontend/src/app/__tests__/dashboard-user.logic.test.ts
+++ b/frontend/src/app/__tests__/dashboard-user.logic.test.ts
@@ -2,32 +2,32 @@ import { describe, expect, it } from 'vitest';
 import { buildDashboardUser } from '../logic/dashboard-user.logic';
 import type { AuthenticatedUser } from '../logic/current-user.types';
 
-const IVAN_PETROV: AuthenticatedUser = {
-  login: 'ipetrov',
-  email: 'i.petrov@rpm.local',
-  firstName: 'Иван',
-  lastName: 'Петров',
+const JOHN_DOE: AuthenticatedUser = {
+  login: 'jdoe',
+  email: 'j.doe@rpm.local',
+  firstName: 'John',
+  lastName: 'Doe',
 };
 
 const LOWERCASE_NAME: AuthenticatedUser = {
-  login: 'asidorova',
-  email: 'a.sidorova@rpm.local',
-  firstName: 'анна',
-  lastName: 'сидорова',
+  login: 'jsmith',
+  email: 'j.smith@rpm.local',
+  firstName: 'jane',
+  lastName: 'smith',
 };
 
 describe('Dashboard User View Model', () => {
   it('derives the display name and avatar initials from the authenticated user', () => {
-    const dashboardUser = buildDashboardUser(IVAN_PETROV);
+    const dashboardUser = buildDashboardUser(JOHN_DOE);
 
-    expect(dashboardUser.displayName).toBe('Иван Петров');
-    expect(dashboardUser.initials).toBe('ИП');
+    expect(dashboardUser.displayName).toBe('John Doe');
+    expect(dashboardUser.initials).toBe('JD');
   });
 
   it('uppercases the initials even when the name is entered in lowercase', () => {
     const dashboardUser = buildDashboardUser(LOWERCASE_NAME);
 
-    expect(dashboardUser.displayName).toBe('анна сидорова');
-    expect(dashboardUser.initials).toBe('АС');
+    expect(dashboardUser.displayName).toBe('jane smith');
+    expect(dashboardUser.initials).toBe('JS');
   });
 });

--- a/frontend/src/app/__tests__/fetch.api.test.ts
+++ b/frontend/src/app/__tests__/fetch.api.test.ts
@@ -10,11 +10,11 @@ const BASE = import.meta.env.VITE_API_URL;
 
 const PROTECTED_PATH = '/api/auth/me';
 
-const IVAN_PETROV: AuthenticatedUser = {
-  login: 'ipetrov',
-  email: 'i.petrov@rpm.local',
-  firstName: 'Иван',
-  lastName: 'Петров',
+const JOHN_DOE: AuthenticatedUser = {
+  login: 'jdoe',
+  email: 'j.doe@rpm.local',
+  firstName: 'John',
+  lastName: 'Doe',
 };
 
 interface Problem {
@@ -57,7 +57,7 @@ describe('Shared API Fetch Layer', () => {
   it('resets the auth session when an API call returns 401', async () => {
     stubProblem(UNAUTHORIZED_PROBLEM);
     const store = useAuthStore();
-    store.$patch({ currentUser: IVAN_PETROV });
+    store.$patch({ currentUser: JOHN_DOE });
 
     const response = await apiFetch(PROTECTED_PATH);
 
@@ -69,12 +69,12 @@ describe('Shared API Fetch Layer', () => {
   it('leaves the auth session intact when an API call returns 403', async () => {
     stubProblem(FORBIDDEN_PROBLEM);
     const store = useAuthStore();
-    store.$patch({ currentUser: IVAN_PETROV });
+    store.$patch({ currentUser: JOHN_DOE });
 
     const response = await apiFetch(PROTECTED_PATH);
 
     expect(response.status).toBe(403);
-    expect(store.currentUser).toEqual(IVAN_PETROV);
+    expect(store.currentUser).toEqual(JOHN_DOE);
     expect(store.isAuthenticated).toBe(true);
   });
 });

--- a/frontend/src/app/components/AppLoading.vue
+++ b/frontend/src/app/components/AppLoading.vue
@@ -8,6 +8,6 @@ import { LoaderCircle } from '@lucide/vue';
     class="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface font-sans"
   >
     <LoaderCircle :size="32" class="animate-spin text-accent" aria-hidden="true" />
-    <div class="text-sm text-muted">Загрузка…</div>
+    <div class="text-sm text-muted">Loading…</div>
   </main>
 </template>

--- a/frontend/src/app/stores/__tests__/auth.store.test.ts
+++ b/frontend/src/app/stores/__tests__/auth.store.test.ts
@@ -11,11 +11,11 @@ const BASE = import.meta.env.VITE_API_URL;
 const ME_PATH = '/api/auth/me';
 const LOGOUT_PATH = '/api/auth/logout';
 
-const IVAN_PETROV: AuthenticatedUser = {
-  login: 'ipetrov',
-  email: 'i.petrov@rpm.local',
-  firstName: 'Иван',
-  lastName: 'Петров',
+const JOHN_DOE: AuthenticatedUser = {
+  login: 'jdoe',
+  email: 'j.doe@rpm.local',
+  firstName: 'John',
+  lastName: 'Doe',
 };
 
 function stubMe(body: JsonBodyType, init: ResponseInit): void {
@@ -26,10 +26,10 @@ function stubMeAuthenticated(): void {
   stubMe(
     {
       userId: '11111111-1111-1111-1111-111111111111',
-      login: 'ipetrov',
-      email: 'i.petrov@rpm.local',
-      firstName: 'Иван',
-      lastName: 'Петров',
+      login: 'jdoe',
+      email: 'j.doe@rpm.local',
+      firstName: 'John',
+      lastName: 'Doe',
       status: 'ACTIVE',
       roles: [],
     },
@@ -82,12 +82,12 @@ describe('Auth Store', () => {
 
     await store.loadMe();
 
-    expect(store.currentUser).toEqual(IVAN_PETROV);
+    expect(store.currentUser).toEqual(JOHN_DOE);
     expect(store.isAuthenticated).toBe(true);
     expect(store.dashboardUser).toEqual({
-      displayName: 'Иван Петров',
-      initials: 'ИП',
-      email: 'i.petrov@rpm.local',
+      displayName: 'John Doe',
+      initials: 'JD',
+      email: 'j.doe@rpm.local',
     });
   });
 
@@ -106,7 +106,7 @@ describe('Auth Store', () => {
     stubCsrfSetsCookie(captured);
     stubLogoutCapturing(captured);
     const store = useAuthStore();
-    store.$patch({ currentUser: IVAN_PETROV });
+    store.$patch({ currentUser: JOHN_DOE });
 
     await store.logout();
 
@@ -117,7 +117,7 @@ describe('Auth Store', () => {
 
   it('clears the current user on reset', () => {
     const store = useAuthStore();
-    store.$patch({ currentUser: IVAN_PETROV });
+    store.$patch({ currentUser: JOHN_DOE });
 
     store.reset();
 

--- a/frontend/src/features/home/__tests__/home.smoke.test.ts
+++ b/frontend/src/features/home/__tests__/home.smoke.test.ts
@@ -51,8 +51,7 @@ describe('HomePage', () => {
     expect(wrapper.find('[data-testid="dashboard-shell"]').exists()).toBe(false);
   });
 
-  // RED — DashboardShell still renders the Russian page title 'Главная' (Task 210); GREEN translates it to 'Home'
-  it.fails('renders the dashboard shell for the current user when authenticated', async () => {
+  it('renders the dashboard shell for the current user when authenticated', async () => {
     stubAuthenticated();
 
     const wrapper = mountHomePage();

--- a/frontend/src/features/home/__tests__/home.smoke.test.ts
+++ b/frontend/src/features/home/__tests__/home.smoke.test.ts
@@ -24,10 +24,10 @@ function stubAuthenticated(): void {
   server.use(
     http.get(`${BASE}${ME_PATH}`, () =>
       HttpResponse.json({
-        login: 'ipetrov',
-        email: 'i.petrov@rpm.local',
-        firstName: 'Иван',
-        lastName: 'Петров',
+        login: 'jdoe',
+        email: 'j.doe@rpm.local',
+        firstName: 'John',
+        lastName: 'Doe',
       }),
     ),
   );
@@ -51,15 +51,16 @@ describe('HomePage', () => {
     expect(wrapper.find('[data-testid="dashboard-shell"]').exists()).toBe(false);
   });
 
-  it('renders the dashboard shell for the current user when authenticated', async () => {
+  // RED — DashboardShell still renders the Russian page title 'Главная' (Task 210); GREEN translates it to 'Home'
+  it.fails('renders the dashboard shell for the current user when authenticated', async () => {
     stubAuthenticated();
 
     const wrapper = mountHomePage();
     await flushPromises();
 
-    expect(wrapper.get('[data-testid="user-name"]').text()).toBe('Иван Петров');
-    expect(wrapper.get('[data-testid="user-avatar"]').text()).toBe('ИП');
-    expect(wrapper.get('[data-testid="page-title"]').text()).toBe('Главная');
+    expect(wrapper.get('[data-testid="user-name"]').text()).toBe('John Doe');
+    expect(wrapper.get('[data-testid="user-avatar"]').text()).toBe('JD');
+    expect(wrapper.get('[data-testid="page-title"]').text()).toBe('Home');
     expect(wrapper.find('[data-testid="welcome-logo"]').exists()).toBe(false);
   });
 });

--- a/frontend/src/features/home/components/DashboardShell.vue
+++ b/frontend/src/features/home/components/DashboardShell.vue
@@ -9,19 +9,19 @@ import DashboardTopBar from './DashboardTopBar.vue';
     <div class="flex min-h-0 flex-1">
       <aside data-testid="dashboard-sidebar" class="flex w-60 shrink-0 items-center justify-center bg-sidebar p-6">
         <div class="text-center text-[13px] leading-normal text-sidebar-muted opacity-50">
-          Разделы появятся<br />по мере подключения модулей
+          Sections will appear<br />as modules are connected
         </div>
       </aside>
       <main class="flex flex-1 flex-col p-8">
-        <h1 data-testid="page-title" class="text-2xl font-bold text-ink">Главная</h1>
+        <h1 data-testid="page-title" class="text-2xl font-bold text-ink">Home</h1>
         <div
           data-testid="dashboard-placeholder"
           class="flex flex-1 flex-col items-center justify-center gap-3 text-center"
         >
           <LayoutDashboard :size="48" class="text-placeholder" aria-hidden="true" />
-          <div class="text-lg font-semibold text-ink">Панель управления</div>
+          <div class="text-lg font-semibold text-ink">Dashboard</div>
           <p class="max-w-90 text-sm leading-normal text-muted">
-            Здесь появятся данные по пациентам, заказам и оповещениям по мере подключения модулей.
+            Patient, order, and alert data will appear here as modules are connected.
           </p>
         </div>
       </main>

--- a/frontend/src/features/home/components/UserMenu.vue
+++ b/frontend/src/features/home/components/UserMenu.vue
@@ -58,7 +58,7 @@ async function handleLogout(): Promise<void> {
         @click="handleLogout"
       >
         <LogOut :size="18" class="text-muted" aria-hidden="true" />
-        Выйти
+        Log out
       </button>
     </div>
   </div>

--- a/frontend/src/features/home/components/WelcomeView.vue
+++ b/frontend/src/features/home/components/WelcomeView.vue
@@ -6,12 +6,9 @@ import { LogIn } from '@lucide/vue';
   <main data-testid="home-page" class="flex min-h-screen items-center justify-center bg-surface font-sans">
     <div class="max-w-120 px-6 text-center">
       <div data-testid="welcome-logo" class="text-5xl font-bold tracking-tight text-accent">RPM</div>
-      <div data-testid="welcome-tagline" class="mt-2 text-lg font-semibold text-ink">
-        Remote Patient Monitoring
-      </div>
+      <div data-testid="welcome-tagline" class="mt-2 text-lg font-semibold text-ink">Remote Patient Monitoring</div>
       <p class="mt-4 text-sm leading-relaxed text-muted">
-        A platform for continuous monitoring of patient health with automatic alerts on abnormal
-        readings.
+        A platform for continuous monitoring of patient health with automatic alerts on abnormal readings.
       </p>
       <RouterLink
         to="/login"

--- a/frontend/src/features/home/components/WelcomeView.vue
+++ b/frontend/src/features/home/components/WelcomeView.vue
@@ -7,11 +7,11 @@ import { LogIn } from '@lucide/vue';
     <div class="max-w-120 px-6 text-center">
       <div data-testid="welcome-logo" class="text-5xl font-bold tracking-tight text-accent">RPM</div>
       <div data-testid="welcome-tagline" class="mt-2 text-lg font-semibold text-ink">
-        Удалённый мониторинг пациентов
+        Remote Patient Monitoring
       </div>
       <p class="mt-4 text-sm leading-relaxed text-muted">
-        Платформа непрерывного наблюдения за состоянием пациентов и автоматических оповещений об отклонениях
-        показателей.
+        A platform for continuous monitoring of patient health with automatic alerts on abnormal
+        readings.
       </p>
       <RouterLink
         to="/login"
@@ -19,7 +19,7 @@ import { LogIn } from '@lucide/vue';
         class="mt-8 inline-flex h-11 items-center justify-center gap-2 rounded-md bg-accent px-8 text-sm font-medium text-white transition-colors hover:bg-accent-hover"
       >
         <LogIn :size="18" aria-hidden="true" />
-        Войти
+        Sign in
       </RouterLink>
     </div>
   </main>


### PR DESCRIPTION
Closes #210.

The product UI language is English (decided during Story 4). Merged `main` still rendered Russian text in the home/dashboard chrome. This change translates every Russian user-visible string to English — **text only, no logic changes** — and keeps tests, the acceptance suite, and the Story 03 mockups consistent.

## Scope (expanded mid-task)

`rg "\p{Cyrillic}"` at fix time surfaced more Russian than the original spec listed — captured in `spec.md` Key Files:

- **Production components:** `WelcomeView`, `DashboardShell`, `UserMenu`, `AppLoading` (`Remote Patient Monitoring`, `Sign in`, `Home`, `Dashboard`, `Log out`, `Loading…`). `lang="en"` was already set in `index.html`.
- **Vitest tests:** flipped expectations to English; sample user renamed to the canonical `John Doe` / `JD`.
- **Playwright home acceptance suite + Statements:** flipped to English (would otherwise break `green-playwright` once components are English).
- **Story 03 mockups (8 HTML files):** translated to stay consistent with the now-English UI (user opted in).

## TDD cycle

red-frontend → red-acceptance-frontend → green-frontend → green-playwright → translate-mockups → demo. RED markers used: Vitest `it.fails`, Playwright `test.fail` — all removed at GREEN.

## Verification

- `rg "\p{Cyrillic}" frontend/src frontend/acceptance ProductSpecification/stories/03-home-page` — clean.
- Vitest: 53 passed. Playwright chromium suite: 25 passed. Lint clean.
- Full-stack journey verdict: **no-impact** (text-only; the nightly journey drives login/activation via already-English Statements and asserts none of the translated home/dashboard strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)