### PR TITLE
Task 221: fix prompt-refactor doc layer violations

### DIFF
--- a/.claude/agents/green-agent.md
+++ b/.claude/agents/green-agent.md
@@ -59,7 +59,7 @@ Frontend layers (all share one template):
 
 ## DB-Tagged Tests: Test DB Required
 
-Before running `acceptance` or `db` adapter tests (`@Tag("db")`), ensure the shared test DB is up — see `.claude/tech/java-spring/infrastructure.md` → "Test Database". Idempotent; reused across runs, never stopped.
+Before running `acceptance` or `db` adapter tests (`@Tag("db")`), ensure the shared test DB is up — see `.claude/tech/{backend}/infrastructure.md` → "Test Database". Idempotent; reused across runs, never stopped.
 
 ## Implementation Rules
 

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -21,7 +21,7 @@ This is a single-module Maven project — `module` is a logical test grouping (a
 
 ## Pre-Check (DB-tagged tests)
 
-Before running `acceptance` or `db` adapter tests, ensure the shared test DB is up — see `.claude/tech/java-spring/infrastructure.md` → "Test Database". This skips the per-run Testcontainer cold-start. Idempotent; never stop it afterward.
+Before running `acceptance` or `db` adapter tests, ensure the shared test DB is up — see `.claude/tech/{backend}/infrastructure.md` → "Test Database". This skips the per-run Testcontainer cold-start. Idempotent; never stop it afterward.
 
 ## Test Commands by Module
 

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -38,6 +38,9 @@ Spawns `refactor-agent` for code improvements.
 - `parameterize-helper.md` - Add parameters to test helpers
 - `inline-test-params.md` - Simplify test→statement data flow
 - `replace-map-with-dto.md` - Replace Map.of() with typed DTO
+- `replace-jsonnode-with-dto.md` - Replace untyped JsonNode traversal with typed DTO
+- `recursive-comparison.md` - Replace manual per-field assertions with recursive comparison
+- `test-data-builder.md` - Extract builder for repeated test entity construction
 - `rest-response-dto.md` - Wrap in REST DTO for snake_case conversion
 - `move-to-data.md` - Move behavior, serialization, factories to data owner
 - `simplify-expressions.md` - Static imports, method references, inline variables
@@ -51,6 +54,7 @@ Spawns `refactor-agent` for code improvements.
 
 - `extract-component.md` - Extract JSX block into field/section component
 - `extract-shared-ui.md` - Move reusable component to `app/components/ui/`
+- `extract-tailwind-class.md` - Extract opaque Tailwind arbitrary-value utilities to an @apply class
 - `extract-test-fixture.md` - Extract MSW response fixtures, stub helpers, assertion helpers
 
 ## Constraints

--- a/.claude/tech/playwright/templates/design-review-patterns.md
+++ b/.claude/tech/playwright/templates/design-review-patterns.md
@@ -1,0 +1,84 @@
+# Design Review Patterns
+
+Reference content for `design-review-agent`: BAD → GOOD examples, the review output format, and verdict examples. The agent classifies every string literal in a component as OK (same value for every user, always) or FAIL (user-, time-, or state-specific). This file shows what the fixes look like and how to report them.
+
+## BAD → GOOD Examples
+
+### Email copied from mockup
+
+```tsx
+// BAD — mockup placeholder hardcoded into the component
+<span data-testid="profile-email">user@example.com</span>
+
+// GOOD — sourced from auth context / API response
+<span data-testid="profile-email">{user.email}</span>
+```
+
+### Date hardcoded
+
+```tsx
+// BAD — fixed date from the mockup
+<p data-testid="renews-on">Renews on Feb 15, 2026</p>
+
+// GOOD — formatted from API data
+<p data-testid="renews-on">Renews on {formatDate(subscription.renewsAt)}</p>
+```
+
+### Price / amount hardcoded
+
+```tsx
+// BAD — plan price baked in
+<span data-testid="plan-price">$9.99/mo</span>
+
+// GOOD — from plan config / API response
+<span data-testid="plan-price">{formatPrice(plan.price)}/mo</span>
+```
+
+### Count tied to user state
+
+```tsx
+// BAD — count from the mockup
+<Badge data-testid="task-count">3 tasks in progress</Badge>
+
+// GOOD — derived from fetched data
+<Badge data-testid="task-count">{inProgressTasks.length} tasks in progress</Badge>
+```
+
+### OK — static UI text stays inline
+
+```tsx
+// OK — same value for every user, every time. Do NOT flag.
+<label htmlFor="email">Email</label>
+<button data-testid="submit">Save</button>
+```
+
+## Output Format
+
+Print one row per reviewed string literal, grouped by verdict. Quote the literal exactly; cite the source line.
+
+```
+## Design Review: {ComponentName}.tsx
+
+| String literal | Line | Verdict | Category | Should come from |
+|----------------|------|---------|----------|------------------|
+| `user@example.com` | 42 | FAIL | Email | Auth context |
+| `Renews on Feb 15, 2026` | 51 | FAIL | Date | API response |
+| `Email` | 18 | OK | UI label | — |
+| `Save` | 63 | OK | Button text | — |
+
+Verdict: FAIL — 2 placeholder values must be made dynamic.
+```
+
+## Verdict Examples
+
+- **PASS** — every string literal is OK (UI labels, headings, button text, ARIA labels, nav paths). No user-, time-, or state-specific value is hardcoded.
+
+  ```
+  Verdict: PASS — no hardcoded placeholder data found. Proceed to /refactor.
+  ```
+
+- **FAIL** — one or more literals are user-, time-, or state-specific. List each with its category and dynamic source. The workflow must NOT proceed to `/refactor` until the flagged values are made dynamic and the review re-run.
+
+  ```
+  Verdict: FAIL — 2 placeholder values must be made dynamic. Fix, then re-run /design-review.
+  ```

--- a/ProductSpecification/tasks/221-refactoring-prompt-refactor-doc-fixes/progress.md
+++ b/ProductSpecification/tasks/221-refactoring-prompt-refactor-doc-fixes/progress.md
@@ -1,0 +1,17 @@
+# Task 221: prompt-refactor doc layer fixes -- Progress
+
+Type: refactoring
+
+## Spec
+- [x] spec
+
+## Fix
+
+### Step 1: Replace hardcoded java-spring path with {backend} placeholder (B6)
+- [x] edit green-agent.md L62 + test-runner.md L24
+
+### Step 2: List the 4 missing refactoring templates in the refactor skill (A5)
+- [x] add replace-jsonnode-with-dto, recursive-comparison, test-data-builder, extract-tailwind-class
+
+### Step 3: Create the missing design-review-patterns.md template (A4/A5)
+- [x] create .claude/tech/playwright/templates/design-review-patterns.md

--- a/ProductSpecification/tasks/221-refactoring-prompt-refactor-doc-fixes/spec.md
+++ b/ProductSpecification/tasks/221-refactoring-prompt-refactor-doc-fixes/spec.md
@@ -1,0 +1,29 @@
+# Task 221: prompt-refactor doc layer fixes
+
+Type: refactoring
+Issue: #221  <- the task number IS the issue number; refactoring records it for traceability but does not tag tests
+
+## Problem
+
+A full `/prompt-refactor` scan of all 8 agents + 30 skills surfaced four objective documentation-layer violations:
+
+1. **B6 tech leakage** — `agents/green-agent.md` (L62) and `agents/test-runner.md` (L24) hardcode `.claude/tech/java-spring/infrastructure.md` instead of the `{backend}` concern placeholder used everywhere else in those files.
+2. **A5 template mismatch** — `skills/refactor/SKILL.md` omits 4 refactoring templates that exist on disk: `replace-jsonnode-with-dto`, `recursive-comparison`, `test-data-builder` (backend) and `extract-tailwind-class` (frontend).
+3. **A4/A5 broken reference** — `agents/design-review-agent.md` (L54, L67) and `skills/design-review/SKILL.md` (L32) all reference `design-review-patterns.md`, which does not exist, leaving the design-review agent with no output-format spec at all.
+
+## Solution
+
+- Replace the hardcoded `java-spring` paths with the `{backend}` placeholder in green-agent and test-runner.
+- Add the 4 missing templates to the refactor skill's Available Templates lists.
+- Create `.claude/tech/playwright/templates/design-review-patterns.md` with the BAD→GOOD examples, review output format, and verdict examples the agent and skill delegate to it.
+
+Documentation-only; no production code or tests affected.
+
+## Key Files
+
+- `.claude/agents/green-agent.md`
+- `.claude/agents/test-runner.md`
+- `.claude/skills/refactor/SKILL.md`
+- `.claude/agents/design-review-agent.md` (references the new template)
+- `.claude/skills/design-review/SKILL.md` (references the new template)
+- `.claude/tech/playwright/templates/design-review-patterns.md` (new)


### PR DESCRIPTION
Closes #221

## Summary

A full `/prompt-refactor` scan of all 8 agents + 30 skills surfaced four objective documentation-layer violations. This PR fixes them. Documentation-only — no production code or tests affected.

## Fixes

| Smell | File | Change |
|-------|------|--------|
| B6 tech leakage | `agents/green-agent.md` L62, `agents/test-runner.md` L24 | Hardcoded `.claude/tech/java-spring/infrastructure.md` → `{backend}` placeholder (matches the rest of each file) |
| A5 template mismatch | `skills/refactor/SKILL.md` | Listed 4 templates that exist on disk but were missing from Available Templates: `replace-jsonnode-with-dto`, `recursive-comparison`, `test-data-builder` (backend), `extract-tailwind-class` (frontend) |
| A4/A5 broken reference | `agents/design-review-agent.md` (L54, L67), `skills/design-review/SKILL.md` (L32) | All three referenced `design-review-patterns.md`, which didn't exist — leaving the design-review agent with no output-format spec. **Created** `.claude/tech/playwright/templates/design-review-patterns.md` with BAD→GOOD examples, review output format, and verdict examples |

## Out of scope (scan noise, deliberately not touched)

- `## Usage` fenced blocks in ~20 skills — intentional, consistent invocation-example convention.
- Borderline tech terms in skills (`run-backend`/`screenshot`/`demo`) — skills are allowed layer-specific context.
- Minor B4 restatements that already reference the canonical rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)