### PR TITLE
fix: unblock nightly full-stack journey — fullstack-seed.sql audit/timezone columns + schema-drift guard (#234)

### DIFF
--- a/src/test/java/by/iivanov/rpm/iam/user/infrastructure/persistence/FullstackSeedSchemaGuardTest.java
+++ b/src/test/java/by/iivanov/rpm/iam/user/infrastructure/persistence/FullstackSeedSchemaGuardTest.java
@@ -1,0 +1,53 @@
+package by.iivanov.rpm.iam.user.infrastructure.persistence;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import by.iivanov.rpm.testing.AbstractApplicationIntegrationTest;
+import by.iivanov.rpm.testing.TestResources;
+import io.qameta.allure.Issue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+/**
+ * Per-PR guard against the full-stack journey seed drifting out of sync with the {@code iam_user}
+ * schema (#234). The nightly journey applies {@code db/fixtures/fullstack-seed.sql} out-of-band via
+ * {@code scripts/seed-fullstack.sh} AFTER the production migrations run; when a story adds a required
+ * column to {@code iam_user} without updating that seed, the nightly fails late at the seeding step.
+ *
+ * <p>This test boots the same production-migrated schema and applies the SAME seed file, so the drift
+ * surfaces on the PR instead of silently in the nightly. It shares the cached full application context
+ * (no second context fork).
+ */
+@Issue("234")
+class FullstackSeedSchemaGuardTest extends AbstractApplicationIntegrationTest {
+
+    private static final String FULLSTACK_SEED = "db/fixtures/fullstack-seed.sql";
+
+    private final JdbcClient jdbcClient;
+
+    FullstackSeedSchemaGuardTest(JdbcClient jdbcClient) {
+        this.jdbcClient = jdbcClient;
+    }
+
+    @Test
+    @DisplayName("WHEN the full-stack journey admin seed runs against the production-migrated schema "
+            + "EXPECT a clean insert that satisfies the NOT NULL audit/timezone columns")
+    @ExpectedToFail(
+            value = "fullstack-seed.sql omits the NOT NULL updated_at/updated_by/time_zone columns added in Story 4",
+            withExceptions = DataIntegrityViolationException.class)
+    void fullstackSeed_appliesAgainstProductionSchema() {
+        String seedSql = TestResources.readUtf8(FULLSTACK_SEED);
+
+        jdbcClient.sql(seedSql).update();
+
+        Long adminsMissingAuditColumns = jdbcClient.sql("""
+                        SELECT COUNT(*) FROM iam_user
+                        WHERE login = 'admin'
+                          AND (updated_at IS NULL OR updated_by IS NULL OR time_zone IS NULL)
+                        """).query(Long.class).single();
+        then(adminsMissingAuditColumns).isZero();
+    }
+}

--- a/src/test/java/by/iivanov/rpm/iam/user/infrastructure/persistence/FullstackSeedSchemaGuardTest.java
+++ b/src/test/java/by/iivanov/rpm/iam/user/infrastructure/persistence/FullstackSeedSchemaGuardTest.java
@@ -32,17 +32,16 @@ class FullstackSeedSchemaGuardTest extends AbstractApplicationIntegrationTest {
 
     @Test
     @DisplayName("WHEN the full-stack journey admin seed runs against the production-migrated schema "
-            + "EXPECT a clean insert that satisfies the NOT NULL audit/timezone columns")
+            + "EXPECT it applies cleanly (no NOT NULL/FK violation) and is idempotent")
     void fullstackSeed_appliesAgainstProductionSchema() {
         String seedSql = TestResources.readUtf8(FULLSTACK_SEED);
 
-        jdbcClient.sql(seedSql).update();
+        int rowsAffected = jdbcClient.sql(seedSql).update();
 
-        Long adminsMissingAuditColumns = jdbcClient.sql("""
-                        SELECT COUNT(*) FROM iam_user
-                        WHERE login = 'admin'
-                          AND (updated_at IS NULL OR updated_by IS NULL OR time_zone IS NULL)
-                        """).query(Long.class).single();
-        then(adminsMissingAuditColumns).isZero();
+        then(rowsAffected)
+                .as("fullstack-seed.sql must apply against the production-migrated iam_user schema "
+                        + "(a missing NOT NULL / FK column would throw here); 0 rows because the journey admin "
+                        + "is already seeded by user.csv in the test context, so ON CONFLICT DO NOTHING is a no-op")
+                .isZero();
     }
 }

--- a/src/test/java/by/iivanov/rpm/iam/user/infrastructure/persistence/FullstackSeedSchemaGuardTest.java
+++ b/src/test/java/by/iivanov/rpm/iam/user/infrastructure/persistence/FullstackSeedSchemaGuardTest.java
@@ -7,8 +7,6 @@ import by.iivanov.rpm.testing.TestResources;
 import io.qameta.allure.Issue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.simple.JdbcClient;
 
 /**
@@ -35,9 +33,6 @@ class FullstackSeedSchemaGuardTest extends AbstractApplicationIntegrationTest {
     @Test
     @DisplayName("WHEN the full-stack journey admin seed runs against the production-migrated schema "
             + "EXPECT a clean insert that satisfies the NOT NULL audit/timezone columns")
-    @ExpectedToFail(
-            value = "fullstack-seed.sql omits the NOT NULL updated_at/updated_by/time_zone columns added in Story 4",
-            withExceptions = DataIntegrityViolationException.class)
     void fullstackSeed_appliesAgainstProductionSchema() {
         String seedSql = TestResources.readUtf8(FULLSTACK_SEED);
 

--- a/src/test/resources/db/fixtures/fullstack-seed.sql
+++ b/src/test/resources/db/fixtures/fullstack-seed.sql
@@ -6,8 +6,10 @@
 -- Idempotent (ON CONFLICT DO NOTHING) so retries / repeated runs are safe.
 -- created_by references the System user (00000000-...-0) inserted by the master changelog.
 INSERT INTO iam_user (id, first_name, middle_name, last_name, email, login,
-                      password_hash, status, created_by, registered_at, version)
+                      password_hash, status, created_by, registered_at, version,
+                      updated_at, updated_by, time_zone)
 VALUES ('019b76da-a800-7000-a957-f5fb8061a532', 'System', 'System', 'System',
         'admin@localhost.com', 'admin', '{noop}admin', 'ACTIVE'::iam_user_status,
-        '00000000-0000-0000-0000-000000000000', '2026-01-01 00:00:00+00', 0)
+        '00000000-0000-0000-0000-000000000000', '2026-01-01 00:00:00+00', 0,
+        '2026-01-01 00:00:00+00', '00000000-0000-0000-0000-000000000000', 'UTC')
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Problem

The nightly full-stack E2E journey (`nightly-fullstack-e2e.yml`) fails deterministically at the **Seed full-stack admin** step — before the Playwright journey runs (run [28314244800](https://github.com/is-ivanov/rpm-ddd/actions/runs/28314244800)), which reopened the umbrella issue #217:

```
ERROR: null value in column "updated_at" of relation "iam_user" violates not-null constraint
```

Story 4 migration `2026.06.27-01-changelog-iam-user-audit.xml` (+ `-02-…-timezone.xml`) added three `NOT NULL` columns to `iam_user` (`updated_at`, `updated_by` FK→`iam_user.id`, `time_zone`). The out-of-band journey seed `src/test/resources/db/fixtures/fullstack-seed.sql` (applied by `scripts/seed-fullstack.sh` via `psql` after the production schema migrates) wasn't updated to populate them. The same admin row in `user.csv` *was* updated by Story 4 — so the two definitions drifted.

## Approach

1. **Fix** — add `updated_at` / `updated_by` / `time_zone` to the seed `INSERT`, mirroring the Story 4 backfill (`updated_at = registered_at`, `updated_by = created_by = System user`, `time_zone = 'UTC'`).
2. **Prevent recurrence** — `FullstackSeedSchemaGuardTest` (`@ApplicationIntegrationTest`) applies the **same** seed file against the real production-migrated schema on every PR (`mvn verify`, tag `db`). A future required column added to `iam_user` without updating the seed now fails on the PR instead of silently in the nightly. (Verified empirically: `ON CONFLICT DO NOTHING` does **not** mask the `NOT NULL` violation even though the admin already exists from `user.csv`.)

Why not load the admin from `user.csv` in the journey: the journey backend runs the `fullstack` profile = production master changelog only; `user.csv`/`db.changelog-test.xml` are test-classpath + `context=test` and are deliberately excluded from the production jar.

## TDD

- **RED** (`477642f`): guard test with `@ExpectedToFail(withExceptions = DataIntegrityViolationException.class)`; ran without the marker → `DataIntegrityViolationException` / `null value in column "updated_at" … not-null` (matches the nightly).
- **GREEN** (`d238202`): seed fixed, marker removed → `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`.

## Verification

- `./mvnw -Dtest=FullstackSeedSchemaGuardTest test` — RED reproduced the nightly failure; GREEN passes against the production-migrated schema (the same migrations + same seed file the nightly uses).
- Static analysis (spotless, checkstyle) clean on changed files.

Closes #234. Umbrella #217 to be closed once the next nightly (or a manual `workflow_dispatch`) is green.
